### PR TITLE
feat(#13): bulk select/delete in EditorScreen, quick-add chain for le…

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,9 +24,7 @@ void main() async {
 
   // Открываем все боксы
   Box<Node> templatesBox = await _openBox<Node>('templates');
-  Box<AppSettings> settingsBox = await _openBox<AppSettings>(
-    'settings',
-  ); // ← добавляем
+  await _openBox<AppSettings>('settings'); // ← больше не сохраняем в переменную
   Box<HistoryEntry> historyBox = await _openBox<HistoryEntry>('history');
   Box<Note> notesBox = await _openBox<Note>('notes');
 
@@ -68,7 +66,6 @@ Future<Box<T>> _openBox<T>(String name) async {
 }
 
 void _migrateExistingPlans(Box<Node> templatesBox, Box<Note> notesBox) {
-  // Создаём временные сервисы только для миграции
   final noteService = NoteService(notesBox);
   final nodeService = NodeService(templatesBox, noteService);
   final plans = nodeService.plans;

--- a/lib/screens/editor_screen.dart
+++ b/lib/screens/editor_screen.dart
@@ -3,7 +3,7 @@ import '../models/node.dart';
 import 'item_card_screen.dart';
 
 class EditorScreen extends StatefulWidget {
-  final Node node; // исходный узел (будет скопирован)
+  final Node node;
 
   const EditorScreen({super.key, required this.node});
 
@@ -16,6 +16,10 @@ class _EditorScreenState extends State<EditorScreen> {
   late TextEditingController _nameController;
   String? _category;
 
+  // Multi‑select state
+  Set<int> _selectedIndices = {};
+  bool _multiSelect = false;
+
   @override
   void initState() {
     super.initState();
@@ -27,30 +31,55 @@ class _EditorScreenState extends State<EditorScreen> {
   @override
   void dispose() {
     _nameController.dispose();
-    // Автосохранение при закрытии экрана (если не было явного сохранения через ✓)
     _saveOnDispose();
     super.dispose();
   }
 
   void _saveOnDispose() {
-    // Сохраняем, даже если пользователь не нажал ✓ (назад или системная кнопка)
     _workingCopy.name = _nameController.text.trim();
     _workingCopy.category = _category;
     Navigator.pop(context, _workingCopy);
   }
 
+  // ----- Mass delete -----
+  void _deleteSelected() {
+    final sorted = _selectedIndices.toList()..sort((a, b) => b.compareTo(a));
+    for (final i in sorted) {
+      _workingCopy.children.removeAt(i);
+    }
+    setState(() {
+      _multiSelect = false;
+      _selectedIndices.clear();
+    });
+  }
+
+  void _cancelSelection() {
+    setState(() {
+      _multiSelect = false;
+      _selectedIndices.clear();
+    });
+  }
+
+  // ----- Quick‑add leaf (chain) -----
   void _addLeaf() async {
-    final newNode = Node.leaf('');
-    final result = await Navigator.push(
-      context,
-      MaterialPageRoute(
-        builder: (context) => ItemCardScreen(node: newNode, isNew: true),
-      ),
-    );
-    if (result != null && result is Node) {
-      setState(() {
-        _workingCopy.children.add(result);
-      });
+    while (true) {
+      final newNode = Node.leaf('');
+      final result = await Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (_) =>
+              ItemCardScreen(node: newNode, isNew: true, quickAdd: true),
+        ),
+      );
+      if (result is Node) {
+        setState(() {
+          _workingCopy.children.add(result);
+        });
+        // continue looping → immediately opens next dialog
+      } else {
+        // user cancelled (returned null)
+        break;
+      }
     }
   }
 
@@ -72,8 +101,7 @@ class _EditorScreenState extends State<EditorScreen> {
     final result = await Navigator.push(
       context,
       MaterialPageRoute(
-        builder: (context) =>
-            ItemCardScreen(node: child.deepCopy(), isNew: false),
+        builder: (_) => ItemCardScreen(node: child.deepCopy(), isNew: false),
       ),
     );
     if (result != null && result is Node) {
@@ -99,15 +127,15 @@ class _EditorScreenState extends State<EditorScreen> {
           onChanged: (value) => _workingCopy.name = value,
         ),
         actions: [
-          // Кнопка "Готово" по-прежнему доступна, но автосохранение при возврате сработает и без неё.
-          IconButton(
-            icon: const Icon(Icons.check),
-            onPressed: () {
-              _workingCopy.name = _nameController.text.trim();
-              _workingCopy.category = _category;
-              Navigator.pop(context, _workingCopy);
-            },
-          ),
+          if (!_multiSelect)
+            IconButton(
+              icon: const Icon(Icons.check),
+              onPressed: () {
+                _workingCopy.name = _nameController.text.trim();
+                _workingCopy.category = _category;
+                Navigator.pop(context, _workingCopy);
+              },
+            ),
         ],
       ),
       body: Column(
@@ -116,7 +144,7 @@ class _EditorScreenState extends State<EditorScreen> {
             Padding(
               padding: const EdgeInsets.all(16.0),
               child: DropdownButtonFormField<String>(
-                value: _category,
+                initialValue: _category,
                 decoration: const InputDecoration(
                   labelText: 'Категория',
                   border: OutlineInputBorder(),
@@ -154,24 +182,24 @@ class _EditorScreenState extends State<EditorScreen> {
                     ],
                   ),
                 ),
-                // Быстрое добавление листа или папки
-                PopupMenuButton<String>(
-                  onSelected: (value) {
-                    if (value == 'leaf') _addLeaf();
-                    if (value == 'folder') _addFolder();
-                  },
-                  itemBuilder: (context) => [
-                    const PopupMenuItem(
-                      value: 'leaf',
-                      child: Text('Добавить лист'),
-                    ),
-                    const PopupMenuItem(
-                      value: 'folder',
-                      child: Text('Добавить папку'),
-                    ),
-                  ],
-                  icon: const Icon(Icons.add),
-                ),
+                if (!_multiSelect)
+                  PopupMenuButton<String>(
+                    onSelected: (value) {
+                      if (value == 'leaf') _addLeaf();
+                      if (value == 'folder') _addFolder();
+                    },
+                    itemBuilder: (context) => [
+                      const PopupMenuItem(
+                        value: 'leaf',
+                        child: Text('Добавить лист'),
+                      ),
+                      const PopupMenuItem(
+                        value: 'folder',
+                        child: Text('Добавить папку'),
+                      ),
+                    ],
+                    icon: const Icon(Icons.add),
+                  ),
               ],
             ),
           ),
@@ -185,6 +213,9 @@ class _EditorScreenState extends State<EditorScreen> {
                 : ReorderableListView.builder(
                     itemCount: _workingCopy.children.length,
                     onReorder: (oldIndex, newIndex) {
+                      if (_multiSelect) {
+                        return;
+                      } // block dragging in selection mode
                       setState(() {
                         if (newIndex > oldIndex) newIndex--;
                         final item = _workingCopy.children.removeAt(oldIndex);
@@ -193,6 +224,7 @@ class _EditorScreenState extends State<EditorScreen> {
                     },
                     itemBuilder: (context, index) {
                       final child = _workingCopy.children[index];
+                      final isSelected = _selectedIndices.contains(index);
                       return Card(
                         key: ValueKey(child),
                         margin: const EdgeInsets.symmetric(
@@ -200,10 +232,23 @@ class _EditorScreenState extends State<EditorScreen> {
                           vertical: 4,
                         ),
                         child: ListTile(
-                          leading: ReorderableDragStartListener(
-                            index: index,
-                            child: const Icon(Icons.drag_handle),
-                          ),
+                          leading: _multiSelect
+                              ? Checkbox(
+                                  value: isSelected,
+                                  onChanged: (val) {
+                                    setState(() {
+                                      if (val == true) {
+                                        _selectedIndices.add(index);
+                                      } else {
+                                        _selectedIndices.remove(index);
+                                      }
+                                    });
+                                  },
+                                )
+                              : ReorderableDragStartListener(
+                                  index: index,
+                                  child: const Icon(Icons.drag_handle),
+                                ),
                           title: Text(
                             child.name.isEmpty ? '[Без названия]' : child.name,
                           ),
@@ -216,25 +261,74 @@ class _EditorScreenState extends State<EditorScreen> {
                               : child.stepType == 'single'
                               ? const Text('Одиночный чекбокс')
                               : const Text('Папка'),
-                          trailing: Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              IconButton(
-                                icon: const Icon(Icons.edit),
-                                onPressed: () => _editChild(index),
-                              ),
-                              IconButton(
-                                icon: const Icon(Icons.delete),
-                                onPressed: () => _deleteChild(index),
-                              ),
-                            ],
-                          ),
-                          onTap: () => _editChild(index),
+                          trailing: _multiSelect
+                              ? null
+                              : Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    IconButton(
+                                      icon: const Icon(Icons.edit),
+                                      onPressed: () => _editChild(index),
+                                    ),
+                                    IconButton(
+                                      icon: const Icon(Icons.delete),
+                                      onPressed: () => _deleteChild(index),
+                                    ),
+                                  ],
+                                ),
+                          onTap: () {
+                            if (_multiSelect) {
+                              setState(() {
+                                if (isSelected) {
+                                  _selectedIndices.remove(index);
+                                } else {
+                                  _selectedIndices.add(index);
+                                }
+                              });
+                            } else {
+                              _editChild(index);
+                            }
+                          },
+                          onLongPress: () {
+                            if (!_multiSelect) {
+                              setState(() {
+                                _multiSelect = true;
+                                _selectedIndices = {index};
+                              });
+                            }
+                          },
                         ),
                       );
                     },
                   ),
           ),
+          // Bottom bar for selection mode
+          if (_multiSelect)
+            Container(
+              color: Theme.of(context).colorScheme.surfaceContainerHighest,
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Row(
+                children: [
+                  Text('Выбрано: ${_selectedIndices.length}'),
+                  const Spacer(),
+                  TextButton(
+                    onPressed: _cancelSelection,
+                    child: const Text('Отмена'),
+                  ),
+                  const SizedBox(width: 8),
+                  ElevatedButton.icon(
+                    onPressed: _selectedIndices.isEmpty
+                        ? null
+                        : _deleteSelected,
+                    icon: const Icon(Icons.delete),
+                    label: const Text('Удалить'),
+                    style: ElevatedButton.styleFrom(
+                      foregroundColor: Colors.red,
+                    ),
+                  ),
+                ],
+              ),
+            ),
         ],
       ),
     );

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -232,7 +232,7 @@ class _HomeScreenState extends State<HomeScreen> {
         );
         return;
       }
-      final newDay = appState.addDayFromTemplate(selected, date);
+      appState.addDayFromTemplate(selected, date);
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text('День "$dateStr" создан из шаблона "${selected.name}"'),

--- a/lib/screens/item_card_screen.dart
+++ b/lib/screens/item_card_screen.dart
@@ -5,8 +5,14 @@ import 'editor_screen.dart';
 class ItemCardScreen extends StatefulWidget {
   final Node node;
   final bool isNew;
+  final bool quickAdd;
 
-  const ItemCardScreen({super.key, required this.node, this.isNew = false});
+  const ItemCardScreen({
+    super.key,
+    required this.node,
+    this.isNew = false,
+    this.quickAdd = false,
+  });
 
   @override
   State<ItemCardScreen> createState() => _ItemCardScreenState();
@@ -20,6 +26,7 @@ class _ItemCardScreenState extends State<ItemCardScreen> {
   late int _totalSteps;
   late int _completedSteps;
   late bool _excludeFromHistory;
+  bool _didSave = false;
 
   @override
   void initState() {
@@ -37,11 +44,18 @@ class _ItemCardScreenState extends State<ItemCardScreen> {
   void dispose() {
     _nameController.dispose();
     _totalStepsController.dispose();
+    if (!_didSave) {
+      if (widget.quickAdd) {
+        Navigator.pop(context, null);
+      } else {
+        _saveOnDispose();
+      }
+    }
     super.dispose();
   }
 
-  void _save() {
-    _workingCopy.name = _nameController.text;
+  void _saveOnDispose() {
+    _workingCopy.name = _nameController.text.trim();
     _workingCopy.stepType = _stepType;
     _workingCopy.totalSteps = _totalSteps;
     _workingCopy.excludeFromHistory = _excludeFromHistory;
@@ -53,6 +67,15 @@ class _ItemCardScreenState extends State<ItemCardScreen> {
       _workingCopy.completed = false;
     }
     Navigator.pop(context, _workingCopy);
+  }
+
+  void _save() {
+    _didSave = true;
+    _saveOnDispose();
+  }
+
+  void _cancel() {
+    Navigator.pop(context, null);
   }
 
   void _openStructureEditor() async {
@@ -148,6 +171,9 @@ class _ItemCardScreenState extends State<ItemCardScreen> {
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.isNew ? 'Новый элемент' : 'Редактировать элемент'),
+        leading: widget.quickAdd
+            ? IconButton(icon: const Icon(Icons.close), onPressed: _cancel)
+            : null,
         actions: [IconButton(icon: const Icon(Icons.check), onPressed: _save)],
       ),
       body: Padding(
@@ -179,18 +205,21 @@ class _ItemCardScreenState extends State<ItemCardScreen> {
                 style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
               ),
               const SizedBox(height: 8),
-              // Возвращаемся к RadioListTile (работает стабильно)
-              RadioListTile<String>(
-                title: const Text('Одиночный чекбокс'),
-                value: 'single',
+              RadioGroup<String>(
                 groupValue: _stepType,
                 onChanged: _onStepTypeChanged,
-              ),
-              RadioListTile<String>(
-                title: const Text('Пошаговый'),
-                value: 'stepByStep',
-                groupValue: _stepType,
-                onChanged: _onStepTypeChanged,
+                child: Column(
+                  children: [
+                    ListTile(
+                      leading: Radio<String>(value: 'single'),
+                      title: const Text('Одиночный чекбокс'),
+                    ),
+                    ListTile(
+                      leading: Radio<String>(value: 'stepByStep'),
+                      title: const Text('Пошаговый'),
+                    ),
+                  ],
+                ),
               ),
               if (_stepType == 'stepByStep') ...[
                 const SizedBox(height: 16),

--- a/lib/screens/notes_screen.dart
+++ b/lib/screens/notes_screen.dart
@@ -35,6 +35,9 @@ class _NotesScreenState extends State<NotesScreen> {
   void _editNote(Note note) => _showNoteEditor(note: note);
 
   void _deleteNote(Note note) async {
+    final appState = context
+        .read<AppState>(); // <-- захватили до асинхронной операции
+
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
@@ -53,7 +56,7 @@ class _NotesScreenState extends State<NotesScreen> {
       ),
     );
     if (confirmed == true) {
-      context.read<AppState>().deleteNote(note.id);
+      appState.deleteNote(note.id);
     }
   }
 

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -14,35 +14,34 @@ class SettingsScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Настройки')),
-      body: ListView(
-        children: [
-          const SizedBox(height: 16),
-          const Padding(
-            padding: EdgeInsets.symmetric(horizontal: 16),
-            child: Text(
-              'Тема оформления',
-              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+      body: RadioGroup<String>(
+        groupValue: currentThemeMode,
+        onChanged: (value) =>
+            onThemeChanged(value!), // <-- добавили ! для String?
+        child: ListView(
+          children: const [
+            SizedBox(height: 16),
+            Padding(
+              padding: EdgeInsets.symmetric(horizontal: 16),
+              child: Text(
+                'Тема оформления',
+                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+              ),
             ),
-          ),
-          RadioListTile<String>(
-            title: const Text('Системная'),
-            value: 'system',
-            groupValue: currentThemeMode,
-            onChanged: (value) => onThemeChanged(value!),
-          ),
-          RadioListTile<String>(
-            title: const Text('Светлая'),
-            value: 'light',
-            groupValue: currentThemeMode,
-            onChanged: (value) => onThemeChanged(value!),
-          ),
-          RadioListTile<String>(
-            title: const Text('Тёмная'),
-            value: 'dark',
-            groupValue: currentThemeMode,
-            onChanged: (value) => onThemeChanged(value!),
-          ),
-        ],
+            ListTile(
+              leading: Radio<String>(value: 'system'),
+              title: Text('Системная'),
+            ),
+            ListTile(
+              leading: Radio<String>(value: 'light'),
+              title: Text('Светлая'),
+            ),
+            ListTile(
+              leading: Radio<String>(value: 'dark'),
+              title: Text('Тёмная'),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/utils/file_transfer.dart
+++ b/lib/utils/file_transfer.dart
@@ -177,8 +177,9 @@ class FileTransfer {
     final data = items.first;
     if (data['templates'] is! List ||
         data['notes'] is! List ||
-        data['history'] is! List)
+        data['history'] is! List) {
       return false;
+    }
 
     await templatesBox.clear();
     await notesBox.clear();

--- a/lib/widgets/activity_calendar.dart
+++ b/lib/widgets/activity_calendar.dart
@@ -377,8 +377,9 @@ class ActivityCalendar extends StatelessWidget {
                                 width: _columnWidth,
                                 child: Column(
                                   children: List.generate(7, (i) {
-                                    if (i >= week.length)
+                                    if (i >= week.length) {
                                       return const SizedBox();
+                                    }
                                     final date = week[i];
                                     final count =
                                         activity[DateTime(


### PR DESCRIPTION
- Multi‑select with long‑press → checkboxes → bulk delete
- Quick‑add chain for leaf items (continuous creation)
- Fix deprecated RadioListTile, cleanup linter warnings
Closes #13, closes #14