### PR TITLE
fix(#20): unique IDs for template copies, auto-save day note

### DIFF
--- a/lib/screens/components/day_note_card.dart
+++ b/lib/screens/components/day_note_card.dart
@@ -46,6 +46,10 @@ class _DayNoteCardState extends State<DayNoteCard> {
 
   @override
   void dispose() {
+    // Автосохранение заметки, если пользователь редактировал и уходит с экрана
+    if (_isEditingNote) {
+      _saveDayNote();
+    }
     _noteController.dispose();
     super.dispose();
   }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
+import 'package:uuid/uuid.dart';
 import '../models/node.dart';
 import '../providers/app_state.dart';
 import 'template_manager_screen.dart';
@@ -120,6 +121,7 @@ class _HomeScreenState extends State<HomeScreen> {
       final appState = context.read<AppState>();
       Node copyAndReset(Node node) {
         final copy = node.deepCopy();
+        copy.id = const Uuid().v4(); // ← гарантированно уникальный ID
         copy.category = 'book';
         if (copy.children.isEmpty) {
           copy.completed = false;

--- a/lib/services/node_service.dart
+++ b/lib/services/node_service.dart
@@ -1,4 +1,5 @@
 import 'package:hive_flutter/hive_flutter.dart';
+import 'package:uuid/uuid.dart';
 import '../models/node.dart';
 import 'note_service.dart';
 
@@ -107,6 +108,7 @@ class NodeService {
 
   Node _copyAndReset(Node node) {
     final copy = node.deepCopy();
+    copy.id = const Uuid().v4(); // ← гарантированно уникальный ID
     if (copy.children.isEmpty) {
       copy.completed = false;
       copy.completedSteps = 0;


### PR DESCRIPTION
- Each plan created from a template now gets a new unique ID, so day notes are not shared.
- Day note auto-saves when leaving the screen without explicit save.
Closes #20