### PR TITLE
Fix #29: Inbox note deletion now works for both old and new notes

### DIFF
--- a/lib/screens/notes_screen.dart
+++ b/lib/screens/notes_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
+import 'package:hive_flutter/hive_flutter.dart'; // Добавлен недостающий импорт
 import '../models/note.dart';
 import '../providers/app_state.dart';
 import 'components/app_drawer_menu.dart';
@@ -35,28 +36,26 @@ class _NotesScreenState extends State<NotesScreen> {
   void _editNote(Note note) => _showNoteEditor(note: note);
 
   void _deleteNote(Note note) async {
-    final appState = context
-        .read<AppState>(); // <-- захватили до асинхронной операции
-
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
-        title: const Text('Удалить заметку?'),
-        content: Text('Заметка "${note.title}" будет удалена.'),
+        title: const Text('Delete note?'),
+        content: Text('The note "${note.title}" will be permanently deleted.'),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(ctx, false),
-            child: const Text('Отмена'),
+            child: const Text('Cancel'),
           ),
           TextButton(
             onPressed: () => Navigator.pop(ctx, true),
-            child: const Text('Удалить', style: TextStyle(color: Colors.red)),
+            child: const Text('Delete', style: TextStyle(color: Colors.red)),
           ),
         ],
       ),
     );
-    if (confirmed == true) {
-      appState.deleteNote(note.id);
+    if (confirmed == true && mounted) {
+      // Добавлена проверка mounted
+      context.read<AppState>().deleteNote(note.id);
     }
   }
 
@@ -84,7 +83,7 @@ class _NotesScreenState extends State<NotesScreen> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(
-                note == null ? 'Новая заметка' : 'Редактировать',
+                note == null ? 'New note' : 'Edit note',
                 style: const TextStyle(
                   fontSize: 18,
                   fontWeight: FontWeight.bold,
@@ -94,7 +93,7 @@ class _NotesScreenState extends State<NotesScreen> {
               TextField(
                 controller: _titleController,
                 decoration: const InputDecoration(
-                  labelText: 'Заголовок',
+                  labelText: 'Title',
                   border: OutlineInputBorder(),
                 ),
               ),
@@ -103,7 +102,7 @@ class _NotesScreenState extends State<NotesScreen> {
                 controller: _contentController,
                 maxLines: 5,
                 decoration: const InputDecoration(
-                  labelText: 'Содержание',
+                  labelText: 'Content',
                   border: OutlineInputBorder(),
                 ),
               ),
@@ -113,7 +112,7 @@ class _NotesScreenState extends State<NotesScreen> {
                 children: [
                   TextButton(
                     onPressed: () => Navigator.pop(ctx),
-                    child: const Text('Отмена'),
+                    child: const Text('Cancel'),
                   ),
                   const SizedBox(width: 8),
                   ElevatedButton(
@@ -127,18 +126,18 @@ class _NotesScreenState extends State<NotesScreen> {
                       final appState = context.read<AppState>();
                       if (note == null) {
                         final newNote = Note(
-                          title: title.isEmpty ? 'Без заголовка' : title,
+                          title: title.isEmpty ? 'Untitled' : title,
                           content: content,
                         );
                         appState.saveNote(newNote);
                       } else {
-                        note.title = title.isEmpty ? 'Без заголовка' : title;
+                        note.title = title.isEmpty ? 'Untitled' : title;
                         note.content = content;
                         appState.saveNote(note);
                       }
                       Navigator.pop(ctx);
                     },
-                    child: Text(note == null ? 'Создать' : 'Сохранить'),
+                    child: Text(note == null ? 'Create' : 'Save'),
                   ),
                 ],
               ),
@@ -158,7 +157,7 @@ class _NotesScreenState extends State<NotesScreen> {
           IconButton(
             icon: const Icon(Icons.add),
             onPressed: _addNote,
-            tooltip: 'Новая заметка',
+            tooltip: 'New note',
           ),
         ],
       ),
@@ -174,13 +173,13 @@ class _NotesScreenState extends State<NotesScreen> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 SearchBar(
-                  hintText: 'Поиск по заметкам...',
+                  hintText: 'Search notes...',
                   leading: const Icon(Icons.search),
                   onChanged: (value) => setState(() => _searchQuery = value),
                 ),
                 const SizedBox(height: 8),
                 const Text(
-                  'Inbox — быстрые заметки без категорий.',
+                  'Inbox — quick notes without categories.',
                   style: TextStyle(fontSize: 12, color: Colors.grey),
                 ),
               ],
@@ -189,65 +188,71 @@ class _NotesScreenState extends State<NotesScreen> {
           Expanded(
             child: Consumer<AppState>(
               builder: (context, appState, _) {
-                final notes = appState.inboxNotes;
-                if (notes.isEmpty) {
-                  return const Center(
-                    child: Text('Нет заметок. Нажмите + чтобы создать.'),
-                  );
-                }
+                // Используем listenable() от бокса через Hive Flutter
+                return ValueListenableBuilder(
+                  valueListenable: appState.notesBox.listenable(),
+                  builder: (context, Box<Note> box, _) {
+                    final notes = appState.inboxNotes;
+                    if (notes.isEmpty) {
+                      return const Center(
+                        child: Text('No notes. Tap + to create one.'),
+                      );
+                    }
 
-                notes.sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+                    notes.sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
 
-                final filtered = _searchQuery.isEmpty
-                    ? notes
-                    : notes.where((note) {
-                        final query = _searchQuery.toLowerCase();
-                        return note.title.toLowerCase().contains(query) ||
-                            note.content.toLowerCase().contains(query);
-                      }).toList();
+                    final filtered = _searchQuery.isEmpty
+                        ? notes
+                        : notes.where((note) {
+                            final query = _searchQuery.toLowerCase();
+                            return note.title.toLowerCase().contains(query) ||
+                                note.content.toLowerCase().contains(query);
+                          }).toList();
 
-                if (filtered.isEmpty) {
-                  return const Center(child: Text('Ничего не найдено'));
-                }
+                    if (filtered.isEmpty) {
+                      return const Center(child: Text('Nothing found'));
+                    }
 
-                return ListView.builder(
-                  itemCount: filtered.length,
-                  itemBuilder: (context, index) {
-                    final note = filtered[index];
-                    return Card(
-                      margin: const EdgeInsets.symmetric(
-                        horizontal: 16,
-                        vertical: 4,
-                      ),
-                      child: ListTile(
-                        title: Text(note.title),
-                        subtitle: Text(
-                          note.content,
-                          maxLines: 2,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                        trailing: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Text(
-                              DateFormat('dd.MM.yy').format(note.updatedAt),
-                              style: const TextStyle(
-                                fontSize: 12,
-                                color: Colors.grey,
-                              ),
+                    return ListView.builder(
+                      itemCount: filtered.length,
+                      itemBuilder: (context, index) {
+                        final note = filtered[index];
+                        return Card(
+                          margin: const EdgeInsets.symmetric(
+                            horizontal: 16,
+                            vertical: 4,
+                          ),
+                          child: ListTile(
+                            title: Text(note.title),
+                            subtitle: Text(
+                              note.content,
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
                             ),
-                            IconButton(
-                              icon: const Icon(Icons.edit, size: 20),
-                              onPressed: () => _editNote(note),
+                            trailing: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Text(
+                                  DateFormat('dd.MM.yy').format(note.updatedAt),
+                                  style: const TextStyle(
+                                    fontSize: 12,
+                                    color: Colors.grey,
+                                  ),
+                                ),
+                                IconButton(
+                                  icon: const Icon(Icons.edit, size: 20),
+                                  onPressed: () => _editNote(note),
+                                ),
+                                IconButton(
+                                  icon: const Icon(Icons.delete, size: 20),
+                                  onPressed: () => _deleteNote(note),
+                                ),
+                              ],
                             ),
-                            IconButton(
-                              icon: const Icon(Icons.delete, size: 20),
-                              onPressed: () => _deleteNote(note),
-                            ),
-                          ],
-                        ),
-                        onTap: () => _editNote(note),
-                      ),
+                            onTap: () => _editNote(note),
+                          ),
+                        );
+                      },
                     );
                   },
                 );

--- a/lib/services/note_service.dart
+++ b/lib/services/note_service.dart
@@ -6,7 +6,6 @@ class NoteService {
 
   NoteService(this._box);
 
-  // ---------- Публичный доступ к боксу ----------
   Box<Note> get box => _box;
 
   Note? getNoteForDay(String linkedNodeId) {
@@ -35,6 +34,25 @@ class NoteService {
   }
 
   void delete(String id) {
-    _box.delete(id);
+    // Сначала пробуем удалить по ключу = id (для новых заметок)
+    if (_box.containsKey(id)) {
+      _box.delete(id);
+      return;
+    }
+    // Если не нашли, ищем заметку, у которой поле id равно переданному id
+    dynamic keyToDelete;
+    for (var key in _box.keys) {
+      final note = _box.get(key);
+      if (note != null && note.id == id) {
+        keyToDelete = key;
+        break;
+      }
+    }
+    if (keyToDelete != null) {
+      _box.delete(keyToDelete);
+    } else {
+      // Если всё равно не нашли, возможно заметка уже удалена
+      print('Note with id $id not found for deletion');
+    }
   }
 }

--- a/lib/widgets/activity_calendar.dart
+++ b/lib/widgets/activity_calendar.dart
@@ -86,7 +86,6 @@ class ActivityCalendar extends StatelessWidget {
       }
       if (label != currentMonth) {
         if (currentMonth != null) {
-          // ignore: unnecessary_non_null_assertion
           final month = currentMonth!;
           headers.add(
             SizedBox(
@@ -107,7 +106,6 @@ class ActivityCalendar extends StatelessWidget {
       }
     }
     if (currentMonth != null) {
-      // ignore: unnecessary_non_null_assertion
       final month = currentMonth!;
       headers.add(
         SizedBox(
@@ -122,10 +120,6 @@ class ActivityCalendar extends StatelessWidget {
       );
     }
     return Row(children: headers);
-  }
-
-  double _calculateMaxScrollExtent(List<List<DateTime>> weeks) {
-    return (weeks.length * _columnWidth) - 300;
   }
 
   bool _isToday(DateTime date) {
@@ -190,10 +184,10 @@ class ActivityCalendar extends StatelessWidget {
   );
 
   void _showDayDetails(
-      BuildContext context,
-      DateTime day,
-      Box<HistoryEntry> historyBox,
-      ) {
+    BuildContext context,
+    DateTime day,
+    Box<HistoryEntry> historyBox,
+  ) {
     initializeDateFormatting('ru');
     final entries = _getEntriesForDay(historyBox, day);
     final dateStr = DateFormat('dd MMMM yyyy', 'ru').format(day);
@@ -227,52 +221,52 @@ class ActivityCalendar extends StatelessWidget {
               const Divider(color: Colors.white24),
               entries.isEmpty
                   ? const Padding(
-                padding: EdgeInsets.all(16),
-                child: Center(
-                  child: Text(
-                    'Нет действий за этот день',
-                    style: TextStyle(color: Colors.white54),
-                  ),
-                ),
-              )
+                      padding: EdgeInsets.all(16),
+                      child: Center(
+                        child: Text(
+                          'Нет действий за этот день',
+                          style: TextStyle(color: Colors.white54),
+                        ),
+                      ),
+                    )
                   : Flexible(
-                child: ListView.builder(
-                  shrinkWrap: true,
-                  itemCount: entries.length,
-                  itemBuilder: (context, index) {
-                    final entry = entries[index];
-                    String action;
-                    IconData icon;
-                    if (entry.stepType == 'single') {
-                      action = entry.completed == true
-                          ? 'Выполнено'
-                          : 'Снято';
-                      icon = entry.completed == true
-                          ? Icons.check_circle
-                          : Icons.radio_button_unchecked;
-                    } else {
-                      action = 'Шагов: ${entry.completedSteps}';
-                      icon = Icons.list;
-                    }
-                    return ListTile(
-                      leading: Icon(
-                        icon,
-                        color: Colors.white70,
-                        size: 20,
+                      child: ListView.builder(
+                        shrinkWrap: true,
+                        itemCount: entries.length,
+                        itemBuilder: (context, index) {
+                          final entry = entries[index];
+                          String action;
+                          IconData icon;
+                          if (entry.stepType == 'single') {
+                            action = entry.completed == true
+                                ? 'Выполнено'
+                                : 'Снято';
+                            icon = entry.completed == true
+                                ? Icons.check_circle
+                                : Icons.radio_button_unchecked;
+                          } else {
+                            action = 'Шагов: ${entry.completedSteps}';
+                            icon = Icons.list;
+                          }
+                          return ListTile(
+                            leading: Icon(
+                              icon,
+                              color: Colors.white70,
+                              size: 20,
+                            ),
+                            title: Text(
+                              entry.nodeName,
+                              style: const TextStyle(color: Colors.white),
+                            ),
+                            trailing: Text(
+                              action,
+                              style: const TextStyle(color: Colors.white54),
+                            ),
+                            dense: true,
+                          );
+                        },
                       ),
-                      title: Text(
-                        entry.nodeName,
-                        style: const TextStyle(color: Colors.white),
-                      ),
-                      trailing: Text(
-                        action,
-                        style: const TextStyle(color: Colors.white54),
-                      ),
-                      dense: true,
-                    );
-                  },
-                ),
-              ),
+                    ),
               const SizedBox(height: 8),
               Align(
                 alignment: Alignment.centerRight,
@@ -310,15 +304,18 @@ class ActivityCalendar extends StatelessWidget {
           );
         }
 
-        final maxScrollExtent = _calculateMaxScrollExtent(
-          weeks,
-        ).clamp(0.0, double.infinity);
+        // Контроллер без initialOffset — будет установлен в post-frame
         final scrollController = ScrollController();
 
-        // Прокрутка к сегодняшнему дню после построения первого кадра
+        // Прокручиваем к самому концу, чтобы последняя неделя была у правого края
         WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (scrollController.hasClients && maxScrollExtent > 0) {
-            scrollController.jumpTo(maxScrollExtent);
+          if (scrollController.hasClients) {
+            final maxScroll = scrollController.position.maxScrollExtent;
+            scrollController.animateTo(
+              maxScroll,
+              duration: const Duration(milliseconds: 300),
+              curve: Curves.easeOut,
+            );
           }
         });
 
@@ -339,103 +336,106 @@ class ActivityCalendar extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(height: 8),
-                SingleChildScrollView(
-                  controller: scrollController,
-                  scrollDirection: Axis.horizontal,
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Column(
-                        children: [
-                          const SizedBox(height: 18),
-                          for (final day in [
-                            'Пн',
-                            '',
-                            'Ср',
-                            '',
-                            'Пт',
-                            '',
-                            'Вс',
-                          ])
-                            SizedBox(
-                              height: _cellSize + _cellMargin * 2,
-                              width: 24,
-                              child: Center(
-                                child: Text(
-                                  day,
-                                  style: const TextStyle(
-                                    fontSize: 9,
-                                    color: Colors.white70,
+                ScrollConfiguration(
+                  behavior: ScrollConfiguration.of(
+                    context,
+                  ).copyWith(scrollbars: false),
+                  child: SingleChildScrollView(
+                    controller: scrollController,
+                    scrollDirection: Axis.horizontal,
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Column(
+                          children: [
+                            const SizedBox(height: 18),
+                            for (final day in [
+                              'Пн',
+                              '',
+                              'Ср',
+                              '',
+                              'Пт',
+                              '',
+                              'Вс',
+                            ])
+                              SizedBox(
+                                height: _cellSize + _cellMargin * 2,
+                                width: 24,
+                                child: Center(
+                                  child: Text(
+                                    day,
+                                    style: const TextStyle(
+                                      fontSize: 9,
+                                      color: Colors.white70,
+                                    ),
                                   ),
                                 ),
                               ),
-                            ),
-                        ],
-                      ),
-                      const SizedBox(width: 8),
-                      Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          _monthHeaders(weeks),
-                          const SizedBox(height: 4),
-                          Row(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: weeks.map((week) {
-                              return SizedBox(
-                                width: _columnWidth,
-                                child: Column(
-                                  children: List.generate(7, (i) {
-                                    if (i >= week.length)
-                                      return const SizedBox();
-                                    final date = week[i];
-                                    final count =
-                                        activity[DateTime(
-                                          date.year,
-                                          date.month,
-                                          date.day,
-                                        )] ??
-                                            0;
-                                    final color = _colorForCount(count);
-                                    final isToday = _isToday(date);
+                          ],
+                        ),
+                        const SizedBox(width: 8),
+                        Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            _monthHeaders(weeks),
+                            const SizedBox(height: 4),
+                            Row(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: weeks.map((week) {
+                                return SizedBox(
+                                  width: _columnWidth,
+                                  child: Column(
+                                    children: List.generate(7, (i) {
+                                      if (i >= week.length)
+                                        return const SizedBox();
+                                      final date = week[i];
+                                      final count =
+                                          activity[DateTime(
+                                            date.year,
+                                            date.month,
+                                            date.day,
+                                          )] ??
+                                          0;
+                                      final color = _colorForCount(count);
+                                      final isToday = _isToday(date);
 
-                                    return GestureDetector(
-                                      onTap: () =>
-                                          _showDayDetails(context, date, box),
-                                      child: Container(
-                                        width: _cellSize,
-                                        height: _cellSize,
-                                        margin: const EdgeInsets.all(
-                                          _cellMargin,
-                                        ),
-                                        decoration: BoxDecoration(
-                                          color: color,
-                                          borderRadius: BorderRadius.circular(
-                                            2,
+                                      return GestureDetector(
+                                        onTap: () =>
+                                            _showDayDetails(context, date, box),
+                                        child: Container(
+                                          width: _cellSize,
+                                          height: _cellSize,
+                                          margin: const EdgeInsets.all(
+                                            _cellMargin,
                                           ),
-                                          border: Border.all(
-                                            color: isToday
-                                                ? Colors.blue.withValues(
-                                              alpha: 0.8,
-                                            )
-                                                : const Color(0x33FFFFFF),
-                                            width: isToday ? 1.5 : 1,
+                                          decoration: BoxDecoration(
+                                            color: color,
+                                            borderRadius: BorderRadius.circular(
+                                              2,
+                                            ),
+                                            border: Border.all(
+                                              color: isToday
+                                                  ? Colors.blue.withAlpha(200)
+                                                  : const Color(0x33FFFFFF),
+                                              width: isToday ? 1.5 : 1,
+                                            ),
+                                          ),
+                                          child: Tooltip(
+                                            message:
+                                                '${DateFormat('dd MMM yyyy').format(date)}\n$count действий${isToday ? ' (сегодня)' : ''}',
+                                            child: const SizedBox.expand(),
                                           ),
                                         ),
-                                        child: Tooltip(
-                                          message:
-                                          '${DateFormat('dd MMM yyyy').format(date)}\n$count действий${isToday ? ' (сегодня)' : ''}',
-                                          child: const SizedBox.expand(),
-                                        ),
-                                      ),
-                                    );
-                                  }),
-                                ),
-                              );
-                            }).toList(),
-                          ),
-                        ],
-                      ),
-                    ],
+                                      );
+                                    }),
+                                  ),
+                                );
+                              }).toList(),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
                   ),
                 ),
                 const SizedBox(height: 12),

--- a/lib/widgets/activity_calendar.dart
+++ b/lib/widgets/activity_calendar.dart
@@ -190,10 +190,10 @@ class ActivityCalendar extends StatelessWidget {
   );
 
   void _showDayDetails(
-    BuildContext context,
-    DateTime day,
-    Box<HistoryEntry> historyBox,
-  ) {
+      BuildContext context,
+      DateTime day,
+      Box<HistoryEntry> historyBox,
+      ) {
     initializeDateFormatting('ru');
     final entries = _getEntriesForDay(historyBox, day);
     final dateStr = DateFormat('dd MMMM yyyy', 'ru').format(day);
@@ -225,55 +225,54 @@ class ActivityCalendar extends StatelessWidget {
                 style: const TextStyle(color: Colors.white70),
               ),
               const Divider(color: Colors.white24),
-              // Заменённый if-else на тернарный оператор
               entries.isEmpty
                   ? const Padding(
-                      padding: EdgeInsets.all(16),
-                      child: Center(
-                        child: Text(
-                          'Нет действий за этот день',
-                          style: TextStyle(color: Colors.white54),
-                        ),
-                      ),
-                    )
+                padding: EdgeInsets.all(16),
+                child: Center(
+                  child: Text(
+                    'Нет действий за этот день',
+                    style: TextStyle(color: Colors.white54),
+                  ),
+                ),
+              )
                   : Flexible(
-                      child: ListView.builder(
-                        shrinkWrap: true,
-                        itemCount: entries.length,
-                        itemBuilder: (context, index) {
-                          final entry = entries[index];
-                          String action;
-                          IconData icon;
-                          if (entry.stepType == 'single') {
-                            action = entry.completed == true
-                                ? 'Выполнено'
-                                : 'Снято';
-                            icon = entry.completed == true
-                                ? Icons.check_circle
-                                : Icons.radio_button_unchecked;
-                          } else {
-                            action = 'Шагов: ${entry.completedSteps}';
-                            icon = Icons.list;
-                          }
-                          return ListTile(
-                            leading: Icon(
-                              icon,
-                              color: Colors.white70,
-                              size: 20,
-                            ),
-                            title: Text(
-                              entry.nodeName,
-                              style: const TextStyle(color: Colors.white),
-                            ),
-                            trailing: Text(
-                              action,
-                              style: const TextStyle(color: Colors.white54),
-                            ),
-                            dense: true,
-                          );
-                        },
+                child: ListView.builder(
+                  shrinkWrap: true,
+                  itemCount: entries.length,
+                  itemBuilder: (context, index) {
+                    final entry = entries[index];
+                    String action;
+                    IconData icon;
+                    if (entry.stepType == 'single') {
+                      action = entry.completed == true
+                          ? 'Выполнено'
+                          : 'Снято';
+                      icon = entry.completed == true
+                          ? Icons.check_circle
+                          : Icons.radio_button_unchecked;
+                    } else {
+                      action = 'Шагов: ${entry.completedSteps}';
+                      icon = Icons.list;
+                    }
+                    return ListTile(
+                      leading: Icon(
+                        icon,
+                        color: Colors.white70,
+                        size: 20,
                       ),
-                    ),
+                      title: Text(
+                        entry.nodeName,
+                        style: const TextStyle(color: Colors.white),
+                      ),
+                      trailing: Text(
+                        action,
+                        style: const TextStyle(color: Colors.white54),
+                      ),
+                      dense: true,
+                    );
+                  },
+                ),
+              ),
               const SizedBox(height: 8),
               Align(
                 alignment: Alignment.centerRight,
@@ -316,6 +315,7 @@ class ActivityCalendar extends StatelessWidget {
         ).clamp(0.0, double.infinity);
         final scrollController = ScrollController();
 
+        // Прокрутка к сегодняшнему дню после построения первого кадра
         WidgetsBinding.instance.addPostFrameCallback((_) {
           if (scrollController.hasClients && maxScrollExtent > 0) {
             scrollController.jumpTo(maxScrollExtent);
@@ -394,7 +394,7 @@ class ActivityCalendar extends StatelessWidget {
                                           date.month,
                                           date.day,
                                         )] ??
-                                        0;
+                                            0;
                                     final color = _colorForCount(count);
                                     final isToday = _isToday(date);
 
@@ -415,15 +415,15 @@ class ActivityCalendar extends StatelessWidget {
                                           border: Border.all(
                                             color: isToday
                                                 ? Colors.blue.withValues(
-                                                    alpha: 0.8,
-                                                  )
+                                              alpha: 0.8,
+                                            )
                                                 : const Color(0x33FFFFFF),
                                             width: isToday ? 1.5 : 1,
                                           ),
                                         ),
                                         child: Tooltip(
                                           message:
-                                              '${DateFormat('dd MMM yyyy').format(date)}\n$count действий${isToday ? ' (сегодня)' : ''}',
+                                          '${DateFormat('dd MMM yyyy').format(date)}\n$count действий${isToday ? ' (сегодня)' : ''}',
                                           child: const SizedBox.expand(),
                                         ),
                                       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: book_tracker
 description: A book learning progress tracker.
 publish_to: 'none'
-version: 1.0.1+4
+version: 1.0.2+4
 
 environment:
   sdk: ^3.11.0


### PR DESCRIPTION
- Added ValueListenableBuilder to notes_screen.dart for reactive UI updates
- Improved NoteService.delete() to find and delete notes by any key type (numeric or string)
- Old notes stored with numeric keys are now properly deleted
Closes #29