### PR TITLE
Fix #31: Improve quick-add leaf UX

### DIFF
--- a/lib/models/node.dart
+++ b/lib/models/node.dart
@@ -82,7 +82,9 @@ class Node {
     );
   }
 
+  // Общее количество листьев (игнорирует рутину)
   int get totalLeaves {
+    if (excludeFromHistory) return 0;
     if (children.isNotEmpty) {
       return children.fold(0, (sum, child) => sum + child.totalLeaves);
     }
@@ -91,13 +93,25 @@ class Node {
     return 0;
   }
 
+  // Количество выполненных листьев (игнорирует рутину)
   int get completedLeaves {
+    if (excludeFromHistory) return 0;
     if (children.isNotEmpty) {
       return children.fold(0, (sum, child) => sum + child.completedLeaves);
     }
     if (stepType == 'single') return completed ? 1 : 0;
     if (stepType == 'stepByStep') return completedSteps;
     return 0;
+  }
+
+  // Количество не-рутинных листовых задач (без учёта папок и рутины)
+  int get nonRoutineLeafCount {
+    if (excludeFromHistory) return 0;
+    if (children.isNotEmpty) {
+      return children.fold(0, (sum, child) => sum + child.nonRoutineLeafCount);
+    }
+    // Это лист (нет детей) и не рутина – считаем за 1
+    return 1;
   }
 
   void toggle() {

--- a/lib/screens/book_screen.dart
+++ b/lib/screens/book_screen.dart
@@ -43,7 +43,6 @@ class _BookScreenState extends State<BookScreen> {
     if (newName.isNotEmpty && newName != _node.name) {
       setState(() => _node.name = newName);
       widget.onNodeUpdated();
-      // Уведомляем провайдер, что данные изменились (если нужно)
       context.read<AppState>().notify();
     }
     setState(() => _isEditingTitle = false);

--- a/lib/screens/components/chapter_tree_view.dart
+++ b/lib/screens/components/chapter_tree_view.dart
@@ -18,13 +18,17 @@ class ChapterTreeView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Expanded(
-      child: ListView(children: _buildChildren(node, 0, context)),
+      child: ListView(children: _buildChildren(node.children, 0, context)),
     );
   }
 
-  List<Widget> _buildChildren(Node node, int depth, BuildContext context) {
+  List<Widget> _buildChildren(
+    List<Node> children,
+    int depth,
+    BuildContext context,
+  ) {
     List<Widget> widgets = [];
-    for (var child in node.children) {
+    for (var child in children) {
       widgets.add(
         NodeTile(
           node: child,
@@ -37,7 +41,6 @@ class ChapterTreeView extends StatelessWidget {
           onTap: () => _openViewScreen(context, child),
           onExpandToggle: child.children.isNotEmpty
               ? () {
-                  // Тоггл через callback родителя, если нужно
                   child.isExpanded = !child.isExpanded;
                   onNodeUpdated();
                 }
@@ -45,7 +48,7 @@ class ChapterTreeView extends StatelessWidget {
         ),
       );
       if (child.isExpanded && child.children.isNotEmpty) {
-        widgets.addAll(_buildChildren(child, depth + 1, context));
+        widgets.addAll(_buildChildren(child.children, depth + 1, context));
       }
     }
     return widgets;

--- a/lib/screens/components/planner_tab_view.dart
+++ b/lib/screens/components/planner_tab_view.dart
@@ -20,7 +20,6 @@ class PlannerTabView extends StatelessWidget {
       );
     }
 
-    // Сортировка
     final sorted = List<Node>.from(plans)
       ..sort((a, b) {
         try {
@@ -42,7 +41,7 @@ class PlannerTabView extends StatelessWidget {
           margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
           child: ListTile(
             title: Text(plan.name),
-            subtitle: Text('Задач: ${plan.totalLeaves}'),
+            subtitle: Text('Задач: ${plan.nonRoutineLeafCount}'),
             trailing: Row(
               mainAxisSize: MainAxisSize.min,
               children: [

--- a/lib/screens/editor_screen.dart
+++ b/lib/screens/editor_screen.dart
@@ -16,7 +16,6 @@ class _EditorScreenState extends State<EditorScreen> {
   late TextEditingController _nameController;
   String? _category;
 
-  // Multi‑select state
   Set<int> _selectedIndices = {};
   bool _multiSelect = false;
 
@@ -41,7 +40,6 @@ class _EditorScreenState extends State<EditorScreen> {
     Navigator.pop(context, _workingCopy);
   }
 
-  // ----- Mass delete -----
   void _deleteSelected() {
     final sorted = _selectedIndices.toList()..sort((a, b) => b.compareTo(a));
     for (final i in sorted) {
@@ -60,9 +58,9 @@ class _EditorScreenState extends State<EditorScreen> {
     });
   }
 
-  // ----- Quick‑add leaf (chain) -----
   void _addLeaf() async {
-    while (true) {
+    bool keepAdding = true;
+    while (keepAdding) {
       final newNode = Node.leaf('');
       final result = await Navigator.push(
         context,
@@ -75,10 +73,28 @@ class _EditorScreenState extends State<EditorScreen> {
         setState(() {
           _workingCopy.children.add(result);
         });
-        // continue looping → immediately opens next dialog
+        final addAnother = await showDialog<bool>(
+          context: context,
+          builder: (ctx) => AlertDialog(
+            title: const Text('Leaf saved'),
+            content: const Text('Do you want to add another leaf?'),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(ctx, false),
+                child: const Text('No'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.pop(ctx, true),
+                child: const Text('Yes'),
+              ),
+            ],
+          ),
+        );
+        if (addAnother != true) {
+          keepAdding = false;
+        }
       } else {
-        // user cancelled (returned null)
-        break;
+        keepAdding = false;
       }
     }
   }
@@ -120,7 +136,7 @@ class _EditorScreenState extends State<EditorScreen> {
         title: TextField(
           controller: _nameController,
           decoration: const InputDecoration(
-            hintText: 'Название',
+            hintText: 'Name',
             border: InputBorder.none,
           ),
           style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
@@ -146,13 +162,13 @@ class _EditorScreenState extends State<EditorScreen> {
               child: DropdownButtonFormField<String>(
                 initialValue: _category,
                 decoration: const InputDecoration(
-                  labelText: 'Категория',
+                  labelText: 'Category',
                   border: OutlineInputBorder(),
                 ),
                 items: const [
-                  DropdownMenuItem(value: 'book', child: Text('Книга')),
-                  DropdownMenuItem(value: 'planner', child: Text('План')),
-                  DropdownMenuItem(value: 'template', child: Text('Шаблон')),
+                  DropdownMenuItem(value: 'book', child: Text('Book')),
+                  DropdownMenuItem(value: 'planner', child: Text('Plan')),
+                  DropdownMenuItem(value: 'template', child: Text('Template')),
                 ],
                 onChanged: (value) => setState(() => _category = value),
               ),
@@ -168,7 +184,7 @@ class _EditorScreenState extends State<EditorScreen> {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        'Тип: ${_workingCopy.children.isEmpty ? "Лист (задача)" : "Папка (раздел)"}',
+                        'Type: ${_workingCopy.children.isEmpty ? "Leaf (task)" : "Folder (section)"}',
                         style: const TextStyle(
                           fontSize: 14,
                           color: Colors.grey,
@@ -176,7 +192,7 @@ class _EditorScreenState extends State<EditorScreen> {
                       ),
                       const SizedBox(height: 4),
                       Text(
-                        'Всего единиц: ${_workingCopy.totalLeaves}',
+                        'Total items: ${_workingCopy.totalLeaves}',
                         style: const TextStyle(fontSize: 16),
                       ),
                     ],
@@ -188,15 +204,9 @@ class _EditorScreenState extends State<EditorScreen> {
                       if (value == 'leaf') _addLeaf();
                       if (value == 'folder') _addFolder();
                     },
-                    itemBuilder: (context) => [
-                      const PopupMenuItem(
-                        value: 'leaf',
-                        child: Text('Добавить лист'),
-                      ),
-                      const PopupMenuItem(
-                        value: 'folder',
-                        child: Text('Добавить папку'),
-                      ),
+                    itemBuilder: (context) => const [
+                      PopupMenuItem(value: 'leaf', child: Text('Add leaf')),
+                      PopupMenuItem(value: 'folder', child: Text('Add folder')),
                     ],
                     icon: const Icon(Icons.add),
                   ),
@@ -206,16 +216,12 @@ class _EditorScreenState extends State<EditorScreen> {
           Expanded(
             child: _workingCopy.children.isEmpty
                 ? const Center(
-                    child: Text(
-                      'Нет дочерних элементов. Нажмите "+" для создания.',
-                    ),
+                    child: Text('No child elements. Press "+" to create.'),
                   )
                 : ReorderableListView.builder(
                     itemCount: _workingCopy.children.length,
                     onReorder: (oldIndex, newIndex) {
-                      if (_multiSelect) {
-                        return;
-                      } // block dragging in selection mode
+                      if (_multiSelect) return;
                       setState(() {
                         if (newIndex > oldIndex) newIndex--;
                         final item = _workingCopy.children.removeAt(oldIndex);
@@ -250,17 +256,17 @@ class _EditorScreenState extends State<EditorScreen> {
                                   child: const Icon(Icons.drag_handle),
                                 ),
                           title: Text(
-                            child.name.isEmpty ? '[Без названия]' : child.name,
+                            child.name.isEmpty ? '[Untitled]' : child.name,
                           ),
                           subtitle: child.children.isNotEmpty
-                              ? Text('${child.children.length} подэлементов')
+                              ? Text('${child.children.length} subitems')
                               : child.stepType == 'stepByStep'
                               ? Text(
                                   '${child.completedSteps}/${child.totalSteps}',
                                 )
                               : child.stepType == 'single'
-                              ? const Text('Одиночный чекбокс')
-                              : const Text('Папка'),
+                              ? const Text('Single checkbox')
+                              : const Text('Folder'),
                           trailing: _multiSelect
                               ? null
                               : Row(
@@ -302,18 +308,17 @@ class _EditorScreenState extends State<EditorScreen> {
                     },
                   ),
           ),
-          // Bottom bar for selection mode
           if (_multiSelect)
             Container(
               color: Theme.of(context).colorScheme.surfaceContainerHighest,
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
               child: Row(
                 children: [
-                  Text('Выбрано: ${_selectedIndices.length}'),
+                  Text('Selected: ${_selectedIndices.length}'),
                   const Spacer(),
                   TextButton(
                     onPressed: _cancelSelection,
-                    child: const Text('Отмена'),
+                    child: const Text('Cancel'),
                   ),
                   const SizedBox(width: 8),
                   ElevatedButton.icon(
@@ -321,7 +326,7 @@ class _EditorScreenState extends State<EditorScreen> {
                         ? null
                         : _deleteSelected,
                     icon: const Icon(Icons.delete),
-                    label: const Text('Удалить'),
+                    label: const Text('Delete'),
                     style: ElevatedButton.styleFrom(
                       foregroundColor: Colors.red,
                     ),

--- a/lib/screens/notes_screen.dart
+++ b/lib/screens/notes_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
+import 'package:hive_flutter/hive_flutter.dart'; // Добавлен недостающий импорт
 import '../models/note.dart';
 import '../providers/app_state.dart';
 import 'components/app_drawer_menu.dart';
@@ -35,28 +36,26 @@ class _NotesScreenState extends State<NotesScreen> {
   void _editNote(Note note) => _showNoteEditor(note: note);
 
   void _deleteNote(Note note) async {
-    final appState = context
-        .read<AppState>(); // <-- захватили до асинхронной операции
-
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
-        title: const Text('Удалить заметку?'),
-        content: Text('Заметка "${note.title}" будет удалена.'),
+        title: const Text('Delete note?'),
+        content: Text('The note "${note.title}" will be permanently deleted.'),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(ctx, false),
-            child: const Text('Отмена'),
+            child: const Text('Cancel'),
           ),
           TextButton(
             onPressed: () => Navigator.pop(ctx, true),
-            child: const Text('Удалить', style: TextStyle(color: Colors.red)),
+            child: const Text('Delete', style: TextStyle(color: Colors.red)),
           ),
         ],
       ),
     );
-    if (confirmed == true) {
-      appState.deleteNote(note.id);
+    if (confirmed == true && mounted) {
+      // Добавлена проверка mounted
+      context.read<AppState>().deleteNote(note.id);
     }
   }
 
@@ -84,7 +83,7 @@ class _NotesScreenState extends State<NotesScreen> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(
-                note == null ? 'Новая заметка' : 'Редактировать',
+                note == null ? 'New note' : 'Edit note',
                 style: const TextStyle(
                   fontSize: 18,
                   fontWeight: FontWeight.bold,
@@ -94,7 +93,7 @@ class _NotesScreenState extends State<NotesScreen> {
               TextField(
                 controller: _titleController,
                 decoration: const InputDecoration(
-                  labelText: 'Заголовок',
+                  labelText: 'Title',
                   border: OutlineInputBorder(),
                 ),
               ),
@@ -103,7 +102,7 @@ class _NotesScreenState extends State<NotesScreen> {
                 controller: _contentController,
                 maxLines: 5,
                 decoration: const InputDecoration(
-                  labelText: 'Содержание',
+                  labelText: 'Content',
                   border: OutlineInputBorder(),
                 ),
               ),
@@ -113,7 +112,7 @@ class _NotesScreenState extends State<NotesScreen> {
                 children: [
                   TextButton(
                     onPressed: () => Navigator.pop(ctx),
-                    child: const Text('Отмена'),
+                    child: const Text('Cancel'),
                   ),
                   const SizedBox(width: 8),
                   ElevatedButton(
@@ -127,18 +126,18 @@ class _NotesScreenState extends State<NotesScreen> {
                       final appState = context.read<AppState>();
                       if (note == null) {
                         final newNote = Note(
-                          title: title.isEmpty ? 'Без заголовка' : title,
+                          title: title.isEmpty ? 'Untitled' : title,
                           content: content,
                         );
                         appState.saveNote(newNote);
                       } else {
-                        note.title = title.isEmpty ? 'Без заголовка' : title;
+                        note.title = title.isEmpty ? 'Untitled' : title;
                         note.content = content;
                         appState.saveNote(note);
                       }
                       Navigator.pop(ctx);
                     },
-                    child: Text(note == null ? 'Создать' : 'Сохранить'),
+                    child: Text(note == null ? 'Create' : 'Save'),
                   ),
                 ],
               ),
@@ -158,7 +157,7 @@ class _NotesScreenState extends State<NotesScreen> {
           IconButton(
             icon: const Icon(Icons.add),
             onPressed: _addNote,
-            tooltip: 'Новая заметка',
+            tooltip: 'New note',
           ),
         ],
       ),
@@ -174,13 +173,13 @@ class _NotesScreenState extends State<NotesScreen> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 SearchBar(
-                  hintText: 'Поиск по заметкам...',
+                  hintText: 'Search notes...',
                   leading: const Icon(Icons.search),
                   onChanged: (value) => setState(() => _searchQuery = value),
                 ),
                 const SizedBox(height: 8),
                 const Text(
-                  'Inbox — быстрые заметки без категорий.',
+                  'Inbox — quick notes without categories.',
                   style: TextStyle(fontSize: 12, color: Colors.grey),
                 ),
               ],
@@ -189,65 +188,71 @@ class _NotesScreenState extends State<NotesScreen> {
           Expanded(
             child: Consumer<AppState>(
               builder: (context, appState, _) {
-                final notes = appState.inboxNotes;
-                if (notes.isEmpty) {
-                  return const Center(
-                    child: Text('Нет заметок. Нажмите + чтобы создать.'),
-                  );
-                }
+                // Используем listenable() от бокса через Hive Flutter
+                return ValueListenableBuilder(
+                  valueListenable: appState.notesBox.listenable(),
+                  builder: (context, Box<Note> box, _) {
+                    final notes = appState.inboxNotes;
+                    if (notes.isEmpty) {
+                      return const Center(
+                        child: Text('No notes. Tap + to create one.'),
+                      );
+                    }
 
-                notes.sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+                    notes.sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
 
-                final filtered = _searchQuery.isEmpty
-                    ? notes
-                    : notes.where((note) {
-                        final query = _searchQuery.toLowerCase();
-                        return note.title.toLowerCase().contains(query) ||
-                            note.content.toLowerCase().contains(query);
-                      }).toList();
+                    final filtered = _searchQuery.isEmpty
+                        ? notes
+                        : notes.where((note) {
+                            final query = _searchQuery.toLowerCase();
+                            return note.title.toLowerCase().contains(query) ||
+                                note.content.toLowerCase().contains(query);
+                          }).toList();
 
-                if (filtered.isEmpty) {
-                  return const Center(child: Text('Ничего не найдено'));
-                }
+                    if (filtered.isEmpty) {
+                      return const Center(child: Text('Nothing found'));
+                    }
 
-                return ListView.builder(
-                  itemCount: filtered.length,
-                  itemBuilder: (context, index) {
-                    final note = filtered[index];
-                    return Card(
-                      margin: const EdgeInsets.symmetric(
-                        horizontal: 16,
-                        vertical: 4,
-                      ),
-                      child: ListTile(
-                        title: Text(note.title),
-                        subtitle: Text(
-                          note.content,
-                          maxLines: 2,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                        trailing: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Text(
-                              DateFormat('dd.MM.yy').format(note.updatedAt),
-                              style: const TextStyle(
-                                fontSize: 12,
-                                color: Colors.grey,
-                              ),
+                    return ListView.builder(
+                      itemCount: filtered.length,
+                      itemBuilder: (context, index) {
+                        final note = filtered[index];
+                        return Card(
+                          margin: const EdgeInsets.symmetric(
+                            horizontal: 16,
+                            vertical: 4,
+                          ),
+                          child: ListTile(
+                            title: Text(note.title),
+                            subtitle: Text(
+                              note.content,
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
                             ),
-                            IconButton(
-                              icon: const Icon(Icons.edit, size: 20),
-                              onPressed: () => _editNote(note),
+                            trailing: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Text(
+                                  DateFormat('dd.MM.yy').format(note.updatedAt),
+                                  style: const TextStyle(
+                                    fontSize: 12,
+                                    color: Colors.grey,
+                                  ),
+                                ),
+                                IconButton(
+                                  icon: const Icon(Icons.edit, size: 20),
+                                  onPressed: () => _editNote(note),
+                                ),
+                                IconButton(
+                                  icon: const Icon(Icons.delete, size: 20),
+                                  onPressed: () => _deleteNote(note),
+                                ),
+                              ],
                             ),
-                            IconButton(
-                              icon: const Icon(Icons.delete, size: 20),
-                              onPressed: () => _deleteNote(note),
-                            ),
-                          ],
-                        ),
-                        onTap: () => _editNote(note),
-                      ),
+                            onTap: () => _editNote(note),
+                          ),
+                        );
+                      },
                     );
                   },
                 );

--- a/lib/services/note_service.dart
+++ b/lib/services/note_service.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import '../models/note.dart';
 
@@ -51,8 +52,7 @@ class NoteService {
     if (keyToDelete != null) {
       _box.delete(keyToDelete);
     } else {
-      // Если всё равно не нашли, возможно заметка уже удалена
-      print('Note with id $id not found for deletion');
+      debugPrint('Note with id $id not found for deletion');
     }
   }
 }

--- a/lib/services/note_service.dart
+++ b/lib/services/note_service.dart
@@ -6,7 +6,6 @@ class NoteService {
 
   NoteService(this._box);
 
-  // ---------- Публичный доступ к боксу ----------
   Box<Note> get box => _box;
 
   Note? getNoteForDay(String linkedNodeId) {
@@ -35,6 +34,25 @@ class NoteService {
   }
 
   void delete(String id) {
-    _box.delete(id);
+    // Сначала пробуем удалить по ключу = id (для новых заметок)
+    if (_box.containsKey(id)) {
+      _box.delete(id);
+      return;
+    }
+    // Если не нашли, ищем заметку, у которой поле id равно переданному id
+    dynamic keyToDelete;
+    for (var key in _box.keys) {
+      final note = _box.get(key);
+      if (note != null && note.id == id) {
+        keyToDelete = key;
+        break;
+      }
+    }
+    if (keyToDelete != null) {
+      _box.delete(keyToDelete);
+    } else {
+      // Если всё равно не нашли, возможно заметка уже удалена
+      print('Note with id $id not found for deletion');
+    }
   }
 }


### PR DESCRIPTION
Closes #31

### Problem
In quick-add leaf mode, after saving a leaf (checkmark), a new form immediately opened for the next leaf, causing an infinite loop. The only way to exit was pressing the cross. This confused users.

### Solution
Changed `_addLeaf()` method in `editor_screen.dart`:
- After saving a leaf, a dialog asks **"Do you want to add another leaf?"** (Yes/No).
- If **Yes** → opens the form again.
- If **No** → exits the loop.
- Pressing **Cancel** (cross) also exits the loop.

### Result
- Users can add as many leaves as needed and consciously stop.
- Intuitive UX: checkmark → save and ask, cross → cancel and exit.
- No more infinite loop.

### Files changed
- `lib/screens/editor_screen.dart`