### PR TITLE
Fix #38: Keep only the latest history entry per day per task

### DIFF
--- a/lib/screens/calendar_screen.dart
+++ b/lib/screens/calendar_screen.dart
@@ -46,12 +46,6 @@ class _CalendarScreenState extends State<CalendarScreen> {
     return _events[normalized] ?? [];
   }
 
-  String _getBookName(String bookId) {
-    final appState = context.read<AppState>();
-    final book = appState.getNodeById(bookId);
-    return book?.name ?? 'Книга удалена';
-  }
-
   Node? _existingPlanForDay(DateTime day) {
     final dateStr = DateFormat('dd.MM.yyyy').format(day);
     final appState = context.read<AppState>();
@@ -165,7 +159,6 @@ class _CalendarScreenState extends State<CalendarScreen> {
       itemCount: events.length,
       itemBuilder: (ctx, index) {
         final entry = events[index];
-        final bookName = _getBookName(entry.bookId);
         return Card(
           margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
           child: ListTile(
@@ -178,7 +171,9 @@ class _CalendarScreenState extends State<CalendarScreen> {
                   )
                 : const Icon(Icons.list, color: Colors.blue),
             title: Text(entry.nodeName),
-            subtitle: Text(bookName),
+            subtitle: Text(
+              entry.nodeName,
+            ), // теперь показывает имя задачи (а не книги)
             trailing: entry.stepType == 'stepByStep'
                 ? Text('Шагов: ${entry.completedSteps}')
                 : null,

--- a/lib/screens/editor_screen.dart
+++ b/lib/screens/editor_screen.dart
@@ -65,9 +65,11 @@ class _EditorScreenState extends State<EditorScreen> {
       final result = await Navigator.push(
         context,
         MaterialPageRoute(
-          builder: (_) => ItemCardScreen(node: newNode, isNew: true, quickAdd: true),
+          builder: (_) =>
+              ItemCardScreen(node: newNode, isNew: true, quickAdd: true),
         ),
       );
+      if (!mounted) return;
       if (result is Node) {
         setState(() {
           _workingCopy.children.add(result);
@@ -89,6 +91,7 @@ class _EditorScreenState extends State<EditorScreen> {
             ],
           ),
         );
+        if (!mounted) return;
         if (addAnother != true) {
           keepAdding = false;
         }
@@ -119,6 +122,7 @@ class _EditorScreenState extends State<EditorScreen> {
         builder: (_) => ItemCardScreen(node: child.deepCopy(), isNew: false),
       ),
     );
+    if (!mounted) return;
     if (result != null && result is Node) {
       setState(() {
         _workingCopy.children[index] = result;
@@ -184,7 +188,10 @@ class _EditorScreenState extends State<EditorScreen> {
                     children: [
                       Text(
                         'Тип: ${_workingCopy.children.isEmpty ? "Лист (задача)" : "Папка (раздел)"}',
-                        style: const TextStyle(fontSize: 14, color: Colors.grey),
+                        style: const TextStyle(
+                          fontSize: 14,
+                          color: Colors.grey,
+                        ),
                       ),
                       const SizedBox(height: 4),
                       Text(
@@ -201,8 +208,14 @@ class _EditorScreenState extends State<EditorScreen> {
                       if (value == 'folder') _addFolder();
                     },
                     itemBuilder: (context) => const [
-                      PopupMenuItem(value: 'leaf', child: Text('Добавить лист')),
-                      PopupMenuItem(value: 'folder', child: Text('Добавить папку')),
+                      PopupMenuItem(
+                        value: 'leaf',
+                        child: Text('Добавить лист'),
+                      ),
+                      PopupMenuItem(
+                        value: 'folder',
+                        child: Text('Добавить папку'),
+                      ),
                     ],
                     icon: const Icon(Icons.add),
                   ),
@@ -212,7 +225,9 @@ class _EditorScreenState extends State<EditorScreen> {
           Expanded(
             child: _workingCopy.children.isEmpty
                 ? const Center(
-                    child: Text('Нет дочерних элементов. Нажмите "+" для создания.'),
+                    child: Text(
+                      'Нет дочерних элементов. Нажмите "+" для создания.',
+                    ),
                   )
                 : ReorderableListView.builder(
                     itemCount: _workingCopy.children.length,
@@ -229,7 +244,10 @@ class _EditorScreenState extends State<EditorScreen> {
                       final isSelected = _selectedIndices.contains(index);
                       return Card(
                         key: ValueKey(child),
-                        margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                        margin: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 4,
+                        ),
                         child: ListTile(
                           leading: _multiSelect
                               ? Checkbox(
@@ -248,14 +266,18 @@ class _EditorScreenState extends State<EditorScreen> {
                                   index: index,
                                   child: const Icon(Icons.drag_handle),
                                 ),
-                          title: Text(child.name.isEmpty ? '[Без названия]' : child.name),
+                          title: Text(
+                            child.name.isEmpty ? '[Без названия]' : child.name,
+                          ),
                           subtitle: child.children.isNotEmpty
                               ? Text('${child.children.length} подэлементов')
                               : child.stepType == 'stepByStep'
-                                  ? Text('${child.completedSteps}/${child.totalSteps}')
-                                  : child.stepType == 'single'
-                                      ? const Text('Одиночный чекбокс')
-                                      : const Text('Папка'),
+                              ? Text(
+                                  '${child.completedSteps}/${child.totalSteps}',
+                                )
+                              : child.stepType == 'single'
+                              ? const Text('Одиночный чекбокс')
+                              : const Text('Папка'),
                           trailing: _multiSelect
                               ? null
                               : Row(
@@ -311,10 +333,14 @@ class _EditorScreenState extends State<EditorScreen> {
                   ),
                   const SizedBox(width: 8),
                   ElevatedButton.icon(
-                    onPressed: _selectedIndices.isEmpty ? null : _deleteSelected,
+                    onPressed: _selectedIndices.isEmpty
+                        ? null
+                        : _deleteSelected,
                     icon: const Icon(Icons.delete),
                     label: const Text('Удалить'),
-                    style: ElevatedButton.styleFrom(foregroundColor: Colors.red),
+                    style: ElevatedButton.styleFrom(
+                      foregroundColor: Colors.red,
+                    ),
                   ),
                 ],
               ),

--- a/lib/screens/view_item_screen.dart
+++ b/lib/screens/view_item_screen.dart
@@ -20,22 +20,26 @@ class ViewItemScreen extends StatefulWidget {
 
 class _ViewItemScreenState extends State<ViewItemScreen> {
   late Node _node;
+  late int _tempSteps; // для плавного отображения слайдера
 
   @override
   void initState() {
     super.initState();
     _node = widget.node;
+    _tempSteps = _node.completedSteps;
   }
 
   void _onToggle(bool? value) {
+    final oldCompleted = _node.completed;
     setState(() {
       _node.completed = value!;
     });
-    if (!_node.excludeFromHistory) {
-      HistoryService.recordToggle(
+    // Записываем только если ставим галочку (false → true)
+    if (!_node.excludeFromHistory && _node.completed && !oldCompleted) {
+      HistoryService.recordUniqueToggle(
         bookId: widget.bookId,
         node: _node,
-        newValue: _node.completed,
+        newValue: true,
       );
     }
     widget.onNodeUpdated();
@@ -43,19 +47,28 @@ class _ViewItemScreenState extends State<ViewItemScreen> {
 
   void _onSliderChanged(double value) {
     setState(() {
-      _node.completedSteps = value.round();
+      _tempSteps = value.round();
     });
   }
 
   void _onSliderChangeEnd(double value) {
-    if (!_node.excludeFromHistory) {
-      HistoryService.recordStepChange(
-        bookId: widget.bookId,
-        node: _node,
-        newSteps: _node.completedSteps,
-      );
+    final newSteps = value.round();
+    final oldSteps = _node.completedSteps;
+    if (newSteps != oldSteps) {
+      setState(() {
+        _node.completedSteps = newSteps;
+        _tempSteps = newSteps;
+      });
+      // Записываем любое изменение (и увеличение, и уменьшение)
+      if (!_node.excludeFromHistory) {
+        HistoryService.recordUniqueProgress(
+          bookId: widget.bookId,
+          node: _node,
+          newSteps: newSteps,
+        );
+      }
+      widget.onNodeUpdated();
     }
-    widget.onNodeUpdated();
   }
 
   @override
@@ -116,7 +129,7 @@ class _ViewItemScreenState extends State<ViewItemScreen> {
                 children: [
                   Expanded(
                     child: Slider(
-                      value: _node.completedSteps.toDouble(),
+                      value: _tempSteps.toDouble(),
                       min: 0,
                       max: _node.totalSteps.toDouble(),
                       divisions: _node.totalSteps,
@@ -124,7 +137,7 @@ class _ViewItemScreenState extends State<ViewItemScreen> {
                       onChangeEnd: _onSliderChangeEnd,
                     ),
                   ),
-                  Text('${_node.completedSteps}/${_node.totalSteps}'),
+                  Text('$_tempSteps/${_node.totalSteps}'),
                 ],
               ),
             ] else if (!isLeaf) ...[

--- a/lib/services/history_service.dart
+++ b/lib/services/history_service.dart
@@ -13,6 +13,8 @@ class HistoryService {
   static Box<HistoryEntry> get _box =>
       _customBox ?? Hive.box<HistoryEntry>('history');
 
+  // ========== Старые методы (оставлены для совместимости) ==========
+
   static void recordToggle({
     required String bookId,
     required Node node,
@@ -40,6 +42,88 @@ class HistoryService {
     );
     _box.add(entry);
   }
+
+  // ========== Новые методы: уникальная запись за день ==========
+
+  /// Удалить старую запись за сегодня для этого узла и добавить новую (для single задач)
+  static void recordUniqueToggle({
+    required String bookId,
+    required Node node,
+    required bool newValue,
+  }) {
+    final today = DateTime.now();
+    final startOfDay = DateTime(today.year, today.month, today.day);
+    final endOfDay = startOfDay.add(const Duration(days: 1));
+
+    // Найти существующую запись за сегодня для этого узла
+    dynamic existingKey;
+    for (var key in _box.keys) {
+      final entry = _box.get(key);
+      if (entry != null &&
+          entry.nodeId == node.id &&
+          entry.date.isAfter(startOfDay) &&
+          entry.date.isBefore(endOfDay)) {
+        existingKey = key;
+        break;
+      }
+    }
+
+    // Удалить старую запись, если есть
+    if (existingKey != null) {
+      _box.delete(existingKey);
+    }
+
+    // Создать новую запись
+    final newEntry = HistoryEntry.forSingle(
+      bookId: bookId,
+      nodeId: node.id,
+      nodeName: node.name,
+      completed: newValue,
+      date: today,
+    );
+    _box.add(newEntry);
+  }
+
+  /// Удалить старую запись за сегодня для этого узла и добавить новую (для stepByStep задач)
+  static void recordUniqueProgress({
+    required String bookId,
+    required Node node,
+    required int newSteps,
+  }) {
+    final today = DateTime.now();
+    final startOfDay = DateTime(today.year, today.month, today.day);
+    final endOfDay = startOfDay.add(const Duration(days: 1));
+
+    // Найти существующую запись за сегодня для этого узла
+    dynamic existingKey;
+    for (var key in _box.keys) {
+      final entry = _box.get(key);
+      if (entry != null &&
+          entry.nodeId == node.id &&
+          entry.date.isAfter(startOfDay) &&
+          entry.date.isBefore(endOfDay)) {
+        existingKey = key;
+        break;
+      }
+    }
+
+    // Удалить старую запись, если есть
+    if (existingKey != null) {
+      _box.delete(existingKey);
+    }
+
+    // Создать новую запись
+    final newEntry = HistoryEntry.forStep(
+      bookId: bookId,
+      nodeId: node.id,
+      nodeName: node.name,
+      completedSteps: newSteps,
+      date: today,
+    );
+    _box.add(newEntry);
+  }
+
+  // ========== Остальные методы (без изменений) ==========
 
   static List<HistoryEntry> getEntriesForDay(DateTime day) {
     final start = DateTime(day.year, day.month, day.day);


### PR DESCRIPTION
- recordUniqueToggle: saves only completed checkboxes, deletes previous entry for today
- recordUniqueProgress: any slider change replaces previous entry for today
- Calendar screen now shows task name instead of book name
- Added mounted checks in editor_screen.dart to avoid async context issues