### PR TITLE
Fix history recording for plans and ensure unique entries per day

### DIFF
--- a/lib/screens/book_screen.dart
+++ b/lib/screens/book_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import '../models/node.dart';
 import '../providers/app_state.dart';
@@ -24,18 +25,23 @@ class _BookScreenState extends State<BookScreen> {
   late Node _node;
   late TextEditingController _nameController;
   bool _isEditingTitle = false;
+  DateTime? _planDate;
 
   @override
   void initState() {
     super.initState();
     _node = widget.node;
     _nameController = TextEditingController(text: _node.name);
+    _planDate = _parsePlanDate();
   }
 
-  @override
-  void dispose() {
-    _nameController.dispose();
-    super.dispose();
+  DateTime? _parsePlanDate() {
+    if (_node.category != 'planner') return null;
+    try {
+      return DateFormat('dd.MM.yyyy').parseStrict(_node.name);
+    } catch (_) {
+      return null; // не удалось распарсить – значит, это не дата
+    }
   }
 
   void _saveTitle() {
@@ -43,6 +49,8 @@ class _BookScreenState extends State<BookScreen> {
     if (newName.isNotEmpty && newName != _node.name) {
       setState(() => _node.name = newName);
       widget.onNodeUpdated();
+      // Обновляем дату после переименования
+      _planDate = _parsePlanDate();
       context.read<AppState>().notify();
     }
     setState(() => _isEditingTitle = false);
@@ -100,6 +108,7 @@ class _BookScreenState extends State<BookScreen> {
               widget.onNodeUpdated();
               setState(() {});
             },
+            planDate: _planDate,
           ),
         ],
       ),

--- a/lib/screens/components/chapter_tree_view.dart
+++ b/lib/screens/components/chapter_tree_view.dart
@@ -7,12 +7,14 @@ class ChapterTreeView extends StatelessWidget {
   final Node node;
   final String bookId;
   final VoidCallback onNodeUpdated;
+  final DateTime? planDate;
 
   const ChapterTreeView({
     super.key,
     required this.node,
     required this.bookId,
     required this.onNodeUpdated,
+    this.planDate,
   });
 
   @override
@@ -45,6 +47,7 @@ class ChapterTreeView extends StatelessWidget {
                   onNodeUpdated();
                 }
               : null,
+          planDate: planDate,
         ),
       );
       if (child.isExpanded && child.children.isNotEmpty) {
@@ -67,6 +70,7 @@ class ChapterTreeView extends StatelessWidget {
           bookId: bookId,
           node: node,
           onNodeUpdated: onNodeUpdated,
+          targetDate: planDate,
         ),
       ),
     );

--- a/lib/screens/view_item_screen.dart
+++ b/lib/screens/view_item_screen.dart
@@ -6,12 +6,14 @@ class ViewItemScreen extends StatefulWidget {
   final String bookId;
   final Node node;
   final VoidCallback onNodeUpdated;
+  final DateTime? targetDate;
 
   const ViewItemScreen({
     super.key,
     required this.bookId,
     required this.node,
     required this.onNodeUpdated,
+    this.targetDate,
   });
 
   @override
@@ -20,7 +22,7 @@ class ViewItemScreen extends StatefulWidget {
 
 class _ViewItemScreenState extends State<ViewItemScreen> {
   late Node _node;
-  late int _tempSteps; // для плавного отображения слайдера
+  late int _tempSteps;
 
   @override
   void initState() {
@@ -30,16 +32,15 @@ class _ViewItemScreenState extends State<ViewItemScreen> {
   }
 
   void _onToggle(bool? value) {
-    final oldCompleted = _node.completed;
     setState(() {
       _node.completed = value!;
     });
-    // Записываем только если ставим галочку (false → true)
-    if (!_node.excludeFromHistory && _node.completed && !oldCompleted) {
+    if (!_node.excludeFromHistory) {
       HistoryService.recordUniqueToggle(
         bookId: widget.bookId,
         node: _node,
-        newValue: true,
+        newValue: _node.completed,
+        targetDate: widget.targetDate,
       );
     }
     widget.onNodeUpdated();
@@ -59,12 +60,12 @@ class _ViewItemScreenState extends State<ViewItemScreen> {
         _node.completedSteps = newSteps;
         _tempSteps = newSteps;
       });
-      // Записываем любое изменение (и увеличение, и уменьшение)
       if (!_node.excludeFromHistory) {
         HistoryService.recordUniqueProgress(
           bookId: widget.bookId,
           node: _node,
           newSteps: newSteps,
+          targetDate: widget.targetDate,
         );
       }
       widget.onNodeUpdated();

--- a/lib/services/history_service.dart
+++ b/lib/services/history_service.dart
@@ -5,7 +5,6 @@ import '../models/node.dart';
 class HistoryService {
   static Box<HistoryEntry>? _customBox;
 
-  /// Позволяет подменить бокс (например, для тестов).
   static void init(Box<HistoryEntry> box) {
     _customBox = box;
   }
@@ -13,123 +12,97 @@ class HistoryService {
   static Box<HistoryEntry> get _box =>
       _customBox ?? Hive.box<HistoryEntry>('history');
 
-  // ========== Старые методы (оставлены для совместимости) ==========
+  // ========== Уникальная запись с поддержкой удаления ==========
 
-  static void recordToggle({
-    required String bookId,
-    required Node node,
-    required bool newValue,
-  }) {
-    final entry = HistoryEntry.forSingle(
-      bookId: bookId,
-      nodeId: node.id,
-      nodeName: node.name,
-      completed: newValue,
-    );
-    _box.add(entry);
-  }
-
-  static void recordStepChange({
-    required String bookId,
-    required Node node,
-    required int newSteps,
-  }) {
-    final entry = HistoryEntry.forStep(
-      bookId: bookId,
-      nodeId: node.id,
-      nodeName: node.name,
-      completedSteps: newSteps,
-    );
-    _box.add(entry);
-  }
-
-  // ========== Новые методы: уникальная запись за день ==========
-
-  /// Удалить старую запись за сегодня для этого узла и добавить новую (для single задач)
+  /// Для одиночных чекбоксов:
+  /// - если newValue == true: удаляем старую запись за сегодня и добавляем новую (выполнено)
+  /// - если newValue == false: удаляем старую запись за сегодня (если есть)
   static void recordUniqueToggle({
     required String bookId,
     required Node node,
     required bool newValue,
+    DateTime? targetDate,
   }) {
-    final today = DateTime.now();
-    final startOfDay = DateTime(today.year, today.month, today.day);
+    final eventDate = targetDate ?? DateTime.now();
+    final startOfDay = DateTime(eventDate.year, eventDate.month, eventDate.day);
     final endOfDay = startOfDay.add(const Duration(days: 1));
 
-    // Найти существующую запись за сегодня для этого узла
     dynamic existingKey;
     for (var key in _box.keys) {
       final entry = _box.get(key);
       if (entry != null &&
           entry.nodeId == node.id &&
-          entry.date.isAfter(startOfDay) &&
-          entry.date.isBefore(endOfDay)) {
+          entry.date.compareTo(startOfDay) >= 0 &&
+          entry.date.compareTo(endOfDay) < 0) {
         existingKey = key;
         break;
       }
     }
 
-    // Удалить старую запись, если есть
     if (existingKey != null) {
       _box.delete(existingKey);
     }
 
-    // Создать новую запись
-    final newEntry = HistoryEntry.forSingle(
-      bookId: bookId,
-      nodeId: node.id,
-      nodeName: node.name,
-      completed: newValue,
-      date: today,
-    );
-    _box.add(newEntry);
+    if (newValue) {
+      final newEntry = HistoryEntry.forSingle(
+        bookId: bookId,
+        nodeId: node.id,
+        nodeName: node.name,
+        completed: true,
+        date: eventDate,
+      );
+      _box.add(newEntry);
+    }
   }
 
-  /// Удалить старую запись за сегодня для этого узла и добавить новую (для stepByStep задач)
+  /// Для пошаговых задач:
+  /// - если newSteps > 0: удаляем старую запись за сегодня и добавляем новую с newSteps
+  /// - если newSteps == 0: удаляем старую запись за сегодня (если есть)
   static void recordUniqueProgress({
     required String bookId,
     required Node node,
     required int newSteps,
+    DateTime? targetDate,
   }) {
-    final today = DateTime.now();
-    final startOfDay = DateTime(today.year, today.month, today.day);
+    final eventDate = targetDate ?? DateTime.now();
+    final startOfDay = DateTime(eventDate.year, eventDate.month, eventDate.day);
     final endOfDay = startOfDay.add(const Duration(days: 1));
 
-    // Найти существующую запись за сегодня для этого узла
     dynamic existingKey;
     for (var key in _box.keys) {
       final entry = _box.get(key);
       if (entry != null &&
           entry.nodeId == node.id &&
-          entry.date.isAfter(startOfDay) &&
-          entry.date.isBefore(endOfDay)) {
+          entry.date.compareTo(startOfDay) >= 0 &&
+          entry.date.compareTo(endOfDay) < 0) {
         existingKey = key;
         break;
       }
     }
 
-    // Удалить старую запись, если есть
     if (existingKey != null) {
       _box.delete(existingKey);
     }
 
-    // Создать новую запись
-    final newEntry = HistoryEntry.forStep(
-      bookId: bookId,
-      nodeId: node.id,
-      nodeName: node.name,
-      completedSteps: newSteps,
-      date: today,
-    );
-    _box.add(newEntry);
+    if (newSteps > 0) {
+      final newEntry = HistoryEntry.forStep(
+        bookId: bookId,
+        nodeId: node.id,
+        nodeName: node.name,
+        completedSteps: newSteps,
+        date: eventDate,
+      );
+      _box.add(newEntry);
+    }
   }
 
-  // ========== Остальные методы (без изменений) ==========
+  // ========== Прочие методы ==========
 
   static List<HistoryEntry> getEntriesForDay(DateTime day) {
     final start = DateTime(day.year, day.month, day.day);
-    final end = DateTime(day.year, day.month, day.day, 23, 59, 59);
+    final end = start.add(const Duration(days: 1));
     return _box.values
-        .where((e) => e.date.isAfter(start) && e.date.isBefore(end))
+        .where((e) => e.date.compareTo(start) >= 0 && e.date.compareTo(end) < 0)
         .toList();
   }
 

--- a/lib/widgets/node_tile.dart
+++ b/lib/widgets/node_tile.dart
@@ -9,6 +9,7 @@ class NodeTile extends StatelessWidget {
   final VoidCallback? onCheckboxChanged;
   final VoidCallback onTap;
   final VoidCallback? onExpandToggle;
+  final DateTime? planDate;
 
   const NodeTile({
     super.key,
@@ -18,6 +19,7 @@ class NodeTile extends StatelessWidget {
     this.onCheckboxChanged,
     required this.onTap,
     this.onExpandToggle,
+    this.planDate,
   });
 
   @override
@@ -51,14 +53,16 @@ class NodeTile extends StatelessWidget {
                   Checkbox(
                     value: node.completed,
                     onChanged: (_) {
+                      final oldCompleted = node.completed;
+                      onCheckboxChanged?.call();
                       if (!node.excludeFromHistory) {
-                        HistoryService.recordToggle(
+                        HistoryService.recordUniqueToggle(
                           bookId: bookId,
                           node: node,
-                          newValue: !node.completed,
+                          newValue: node.completed,
+                          targetDate: planDate,
                         );
                       }
-                      onCheckboxChanged?.call();
                     },
                   ),
                   Expanded(


### PR DESCRIPTION
- Use plan's date (parsed from plan name) for history entries instead of current date
- Delete previous history entry for the same day before adding a new one (unique per day)
- For single tasks: record only when checkbox is checked; unchecking deletes the entry
- For step-by-step tasks: record only when progress > 0; setting to 0 deletes the entry
- Calendar now shows only actual completions without leftover entries from unchecked tasks
- Pass planDate down through ChapterTreeView, NodeTile to ViewItemScreen for correct date handling