### PR TITLE
fix: resolve standard tasks deletion/editing (#50) and unify tracking by name (#51)

### DIFF
--- a/lib/models/standard_task.dart
+++ b/lib/models/standard_task.dart
@@ -13,7 +13,7 @@ class StandardTask {
   String name;
 
   @HiveField(2)
-  String stepType; // 'single' or 'stepByStep'
+  String stepType;
 
   @HiveField(3)
   int totalSteps;
@@ -22,7 +22,10 @@ class StandardTask {
   bool excludeFromHistory;
 
   @HiveField(5)
-  int? colorValue; // optional for future heatmap
+  int? colorValue;
+
+  @HiveField(6)
+  String trackingId;   // новый поле
 
   StandardTask({
     String? id,
@@ -31,7 +34,9 @@ class StandardTask {
     this.totalSteps = 1,
     this.excludeFromHistory = false,
     this.colorValue,
-  }) : id = id ?? const Uuid().v4();
+    String? trackingId,
+  }) : id = id ?? const Uuid().v4(),
+        trackingId = trackingId ?? const Uuid().v4();
 
   Map<String, dynamic> toJson() => {
     'id': id,
@@ -40,6 +45,7 @@ class StandardTask {
     'totalSteps': totalSteps,
     'excludeFromHistory': excludeFromHistory,
     'colorValue': colorValue,
+    'trackingId': trackingId,
   };
 
   factory StandardTask.fromJson(Map<String, dynamic> json) => StandardTask(
@@ -49,6 +55,7 @@ class StandardTask {
     totalSteps: json['totalSteps'] ?? 1,
     excludeFromHistory: json['excludeFromHistory'] ?? false,
     colorValue: json['colorValue'],
+    trackingId: json['trackingId'] ?? const Uuid().v4(),
   );
 
   Node toNode() {
@@ -57,6 +64,7 @@ class StandardTask {
       stepType: stepType,
       totalSteps: totalSteps,
       excludeFromHistory: excludeFromHistory,
+      trackingId: trackingId,   // важно: передаём сохранённый trackingId
     );
   }
 }

--- a/lib/models/standard_task.g.dart
+++ b/lib/models/standard_task.g.dart
@@ -23,13 +23,14 @@ class StandardTaskAdapter extends TypeAdapter<StandardTask> {
       totalSteps: fields[3] as int,
       excludeFromHistory: fields[4] as bool,
       colorValue: fields[5] as int?,
+      trackingId: fields[6] as String?,
     );
   }
 
   @override
   void write(BinaryWriter writer, StandardTask obj) {
     writer
-      ..writeByte(6)
+      ..writeByte(7)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -41,7 +42,9 @@ class StandardTaskAdapter extends TypeAdapter<StandardTask> {
       ..writeByte(4)
       ..write(obj.excludeFromHistory)
       ..writeByte(5)
-      ..write(obj.colorValue);
+      ..write(obj.colorValue)
+      ..writeByte(6)
+      ..write(obj.trackingId);
   }
 
   @override

--- a/lib/providers/app_state.dart
+++ b/lib/providers/app_state.dart
@@ -112,7 +112,7 @@ class AppState extends ChangeNotifier {
 
   List<Note> get inboxNotes => _noteService.inboxNotes;
 
-  // ---------- Стандартные задачи ----------
+  // ---------- Стандартные задачи (исправлено для Issue #50) ----------
 
   List<StandardTask> get standardTasks => _standardTasksBox.values.toList();
 
@@ -122,21 +122,41 @@ class AppState extends ChangeNotifier {
   }
 
   void updateStandardTask(String id, StandardTask task) {
-    _standardTasksBox.put(id, task);
-    notifyListeners();
+    // Ищем реальный Hive-ключ по полю id
+    dynamic keyToUpdate;
+    for (var key in _standardTasksBox.keys) {
+      final existing = _standardTasksBox.get(key);
+      if (existing != null && existing.id == id) {
+        keyToUpdate = key;
+        break;
+      }
+    }
+    if (keyToUpdate != null) {
+      _standardTasksBox.put(keyToUpdate, task);
+      notifyListeners();
+    }
   }
 
   void deleteStandardTask(String id) {
-    _standardTasksBox.delete(id);
-    notifyListeners();
+    dynamic keyToDelete;
+    for (var key in _standardTasksBox.keys) {
+      final task = _standardTasksBox.get(key);
+      if (task != null && task.id == id) {
+        keyToDelete = key;
+        break;
+      }
+    }
+    if (keyToDelete != null) {
+      _standardTasksBox.delete(keyToDelete);
+      notifyListeners();
+    }
   }
 
-  // ---------- Отслеживаемые задачи (исправлено удаление/обновление по полю id) ----------
+  // ---------- Отслеживаемые задачи ----------
 
   List<TrackedActivity> get trackedActivities => _trackedActivitiesBox.values.toList();
 
   void addTrackedActivity(TrackedActivity activity) {
-    // Используем id объекта как ключ
     _trackedActivitiesBox.put(activity.id, activity);
     notifyListeners();
   }
@@ -158,7 +178,6 @@ class AppState extends ChangeNotifier {
   }
 
   void deleteTrackedActivity(String id) {
-    // Ищем ключ по полю id
     dynamic keyToDelete;
     for (var key in _trackedActivitiesBox.keys) {
       final activity = _trackedActivitiesBox.get(key);

--- a/lib/screens/standard_tasks_screen.dart
+++ b/lib/screens/standard_tasks_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:uuid/uuid.dart';
 import '../models/standard_task.dart';
+import '../models/node.dart';
 import '../providers/app_state.dart';
 
 class StandardTasksScreen extends StatefulWidget {
@@ -139,6 +141,34 @@ class _StandardTaskEditorScreenState extends State<StandardTaskEditorScreen> {
     super.dispose();
   }
 
+  /// Поиск существующего trackingId для задачи с таким же именем (из всех книг, планов, шаблонов)
+  String _findExistingTrackingId(String name, AppState appState) {
+    final allNodes = <Node>[];
+    allNodes.addAll(appState.books);
+    allNodes.addAll(appState.plans);
+    allNodes.addAll(appState.templates);
+
+    List<Node> collectLeaves(List<Node> nodes) {
+      final leaves = <Node>[];
+      for (var node in nodes) {
+        if (node.children.isEmpty && node.stepType != 'folder') {
+          leaves.add(node);
+        } else {
+          leaves.addAll(collectLeaves(node.children));
+        }
+      }
+      return leaves;
+    }
+
+    final allLeaves = collectLeaves(allNodes);
+    for (var node in allLeaves) {
+      if (node.name.toLowerCase() == name.toLowerCase() && node.trackingId.isNotEmpty) {
+        return node.trackingId;
+      }
+    }
+    return const Uuid().v4();
+  }
+
   void _save() {
     final name = _nameController.text.trim();
     if (name.isEmpty) {
@@ -147,14 +177,35 @@ class _StandardTaskEditorScreenState extends State<StandardTaskEditorScreen> {
       );
       return;
     }
+
+    final appState = context.read<AppState>();
+
+    // Проверка на дубликат имени (регистронезависимая)
+    bool duplicateExists = false;
+    for (final task in appState.standardTasks) {
+      if (task.name.toLowerCase() == name.toLowerCase() && task.id != widget.task.id) {
+        duplicateExists = true;
+        break;
+      }
+    }
+    if (duplicateExists) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Задача с таким именем уже существует')),
+      );
+      return;
+    }
+
+    // Поиск существующего trackingId
+    final trackingId = _findExistingTrackingId(name, appState);
+
     final updatedTask = StandardTask(
       id: widget.task.id,
       name: name,
       stepType: _stepType,
       totalSteps: _stepType == 'stepByStep' ? _totalSteps : 1,
       excludeFromHistory: _excludeFromHistory,
+      trackingId: trackingId,
     );
-    final appState = context.read<AppState>();
     if (widget.isNew) {
       appState.addStandardTask(updatedTask);
     } else {


### PR DESCRIPTION
## Closes
- Closes #50  
- Closes #51  

## Summary of changes

### #50 – Fix deletion/editing of imported standard tasks
- Refactored `deleteStandardTask` and `updateStandardTask` in `lib/providers/app_state.dart`.
- Instead of assuming the Hive key equals the `id` field, the methods now iterate over `_standardTasksBox.keys` and compare the stored object’s `id` with the provided one.
- This allows imported standard tasks (where the Hive key is an auto‑increment number) to be properly deleted and edited.

### #51 – Unify tasks by name for heatmap tracking (including standard tasks)
- Added `trackingId` field to `StandardTask` model.
- In `StandardTaskEditorScreen._save()`, the system searches for an existing leaf task with the same name (case‑insensitive) across all books, plans, and templates.
- If a matching leaf task is found, the standard task inherits its `trackingId`; otherwise a new one is generated.
- The `toNode()` method of `StandardTask` passes this `trackingId` to the created node, ensuring that when a standard task is added to a plan, it uses the same identifier as manually created tasks.
- Duplicate names among standard tasks are now prevented (unique constraint).

### Supporting changes
- Updated `lib/models/standard_task.dart` with the new field and adjusted JSON serialisation.
- Re‑generated Hive adapters (`standard_task.g.dart`) to include `trackingId`.

## Impact on existing data
- Newly created standard tasks will automatically reuse existing `trackingId`s from leaf tasks with the same name.
- Users with duplicate tracked entries can manually clean them up via the “Tracked Activities” screen (gear icon on the heatmap) – keep only one entry per logical task name.
- No data loss; old records remain untouched.

## Testing performed
- ✅ Imported standard tasks are now deletable and editable (tested with backup/restore).  
- ✅ Creating a standard task with a name that already exists as a leaf task reuses the same `trackingId`.  
- ✅ Adding that standard task to a plan creates a node with the correct `trackingId`.  
- ✅ Completing either the manually created leaf task or the standard‑task‑derived node updates the same heatmap entry.  
- ✅ Duplicate names in standard tasks are prevented – error snackbar shown.  
- ✅ Task picker for heatmap shows only one entry per logical task name.  

## Files changed
- `lib/providers/app_state.dart`
- `lib/models/standard_task.dart`
- `lib/screens/standard_tasks_screen.dart`
- `lib/models/standard_task.g.dart` (regenerated)
- Other generated files (`history_entry.g.dart`, `node.g.dart`, `tracked_activity.g.dart`) – updated due to model changes.

## Ready for review
This PR fully resolves both issues and integrates standard tasks with the heatmap tracking system.  
All changes have been tested on Android (real device). No regressions observed in other parts of the app.