### PR TITLE
Release v1.1.1: Fix heatmap aggregation for duplicate task instances

### DIFF
--- a/lib/screens/tracked_activities_screen.dart
+++ b/lib/screens/tracked_activities_screen.dart
@@ -32,6 +32,43 @@ class _TrackedActivitiesScreenState extends State<TrackedActivitiesScreen> {
     if (!mounted) return;
     if (selectedNode == null) return;
 
+    final appState = Provider.of<AppState>(context, listen: false);
+
+    // Проверяем, есть ли уже задача с таким trackingId (в любом состоянии)
+    TrackedActivity? existing;
+    for (final a in appState.trackedActivities) {
+      if (a.nodeId == selectedNode.trackingId) {
+        existing = a;
+        break;
+      }
+    }
+
+    if (existing != null) {
+      // Уже есть – активируем, если была выключена
+      if (!existing.isActive) {
+        final updated = TrackedActivity(
+          id: existing.id,
+          nodeId: existing.nodeId,
+          name: existing.name,
+          colorValue: existing.colorValue,
+          stepType: existing.stepType,
+          isActive: true,
+          isRoutine: existing.isRoutine,
+        );
+        appState.updateTrackedActivity(existing.id, updated);
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Задача включена обратно')),
+        );
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Задача уже отслеживается')),
+        );
+      }
+      setState(() {});
+      return;
+    }
+
+    // Новая задача – выбрать цвет
     Color? selectedColor = await showDialog<Color>(
       context: context,
       builder: (ctx) => AlertDialog(
@@ -53,20 +90,21 @@ class _TrackedActivitiesScreenState extends State<TrackedActivitiesScreen> {
     if (!mounted) return;
     if (selectedColor == null) return;
 
-    // ВАЖНО: используем trackingId вместо node.id
     final newActivity = TrackedActivity(
-      nodeId: selectedNode.trackingId,   // ← постоянный идентификатор
+      nodeId: selectedNode.trackingId,
       name: selectedNode.name,
       colorValue: selectedColor.toARGB32(),
       stepType: selectedNode.stepType,
       isActive: true,
     );
 
-    Provider.of<AppState>(context, listen: false).addTrackedActivity(newActivity);
+    appState.addTrackedActivity(newActivity);
     setState(() {});
   }
 
   void _toggleActive(TrackedActivity activity, bool value) {
+    final appState = Provider.of<AppState>(context, listen: false);
+    // Обновляем только существующую запись
     final updated = TrackedActivity(
       id: activity.id,
       nodeId: activity.nodeId,
@@ -74,9 +112,9 @@ class _TrackedActivitiesScreenState extends State<TrackedActivitiesScreen> {
       colorValue: activity.colorValue,
       stepType: activity.stepType,
       isActive: value,
+      isRoutine: activity.isRoutine,
     );
-    Provider.of<AppState>(context, listen: false)
-        .updateTrackedActivity(activity.id, updated);
+    appState.updateTrackedActivity(activity.id, updated);
     setState(() {});
   }
 
@@ -100,8 +138,8 @@ class _TrackedActivitiesScreenState extends State<TrackedActivitiesScreen> {
     );
     if (!mounted) return;
     if (confirmed == true) {
-      Provider.of<AppState>(context, listen: false)
-          .deleteTrackedActivity(activity.id);
+      final appState = Provider.of<AppState>(context, listen: false);
+      appState.deleteTrackedActivity(activity.id);
       setState(() {});
     }
   }

--- a/lib/services/history_service.dart
+++ b/lib/services/history_service.dart
@@ -23,22 +23,10 @@ class HistoryService {
     final startOfDay = DateTime(eventDate.year, eventDate.month, eventDate.day);
     final endOfDay = startOfDay.add(const Duration(days: 1));
 
-    dynamic existingKey;
-    for (var key in _box.keys) {
-      final entry = _box.get(key);
-      if (entry != null &&
-          entry.trackingId == node.trackingId &&   // сравниваем по trackingId
-          entry.date.compareTo(startOfDay) >= 0 &&
-          entry.date.compareTo(endOfDay) < 0) {
-        existingKey = key;
-        break;
-      }
-    }
+    // Удаляем существующую запись для этого конкретного экземпляра (nodeId)
+    _deleteEntryByNodeId(node.id, startOfDay, endOfDay);
 
-    if (existingKey != null) {
-      _box.delete(existingKey);
-    }
-
+    // Если новое значение true – создаём новую запись
     if (newValue) {
       final newEntry = HistoryEntry.forSingle(
         bookId: bookId,
@@ -63,22 +51,10 @@ class HistoryService {
     final startOfDay = DateTime(eventDate.year, eventDate.month, eventDate.day);
     final endOfDay = startOfDay.add(const Duration(days: 1));
 
-    dynamic existingKey;
-    for (var key in _box.keys) {
-      final entry = _box.get(key);
-      if (entry != null &&
-          entry.trackingId == node.trackingId &&
-          entry.date.compareTo(startOfDay) >= 0 &&
-          entry.date.compareTo(endOfDay) < 0) {
-        existingKey = key;
-        break;
-      }
-    }
+    // Удаляем существующую запись для этого конкретного экземпляра (nodeId)
+    _deleteEntryByNodeId(node.id, startOfDay, endOfDay);
 
-    if (existingKey != null) {
-      _box.delete(existingKey);
-    }
-
+    // Если прогресс > 0 – создаём новую запись
     if (newSteps > 0) {
       final newEntry = HistoryEntry.forStep(
         bookId: bookId,
@@ -89,6 +65,24 @@ class HistoryService {
         date: eventDate,
       );
       _box.add(newEntry);
+    }
+  }
+
+  // Вспомогательный метод для удаления записи по nodeId
+  static void _deleteEntryByNodeId(String nodeId, DateTime start, DateTime end) {
+    dynamic keyToDelete;
+    for (var key in _box.keys) {
+      final entry = _box.get(key);
+      if (entry != null &&
+          entry.nodeId == nodeId &&
+          entry.date.isAfter(start) &&
+          entry.date.isBefore(end)) {
+        keyToDelete = key;
+        break;
+      }
+    }
+    if (keyToDelete != null) {
+      _box.delete(keyToDelete);
     }
   }
 

--- a/lib/services/node_service.dart
+++ b/lib/services/node_service.dart
@@ -33,7 +33,9 @@ class NodeService {
     final node = _box.get(key);
     if (node != null) {
       final notes = _noteService.getNotesForNode(node.id);
-      for (final note in notes) _noteService.delete(note.id);
+      for (final note in notes) {
+        _noteService.delete(note.id);
+      }
     }
     _box.delete(key);
   }


### PR DESCRIPTION
This PR merges the latest develop branch into main for a patch release v1.1.1.
It addresses a critical bug where the heatmap failed to sum progress for multiple identical task instances on the same day (e.g., "Tai Chi" performed both in the morning and evening). Now each occurrence is recorded separately, and the heatmap correctly aggregates the total per day.

Key changes included

Fix #56 – Heatmap now sums progress per nodeId instead of trackingId, allowing multiple instances of the same task to contribute cumulatively.

All previous improvements from develop (standard tasks tracking, UI enhancements, and bug fixes) are already included.

Testing

The fix has been tested in the develop branch and verified with multiple duplicated tasks in a single day.

No regressions were observed in other parts of the app (calendar, statistics, etc.).

Related issues

Closes #56 – Heatmap does not sum progress for multiple instances of the same task on the same day.

Version

Bump version to 1.1.1 (patch) in pubspec.yaml before merging (or after).